### PR TITLE
Fix empty string being serialized as text attachment

### DIFF
--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/model/ErrorAttachment.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/model/ErrorAttachment.java
@@ -80,7 +80,7 @@ public class ErrorAttachment implements Model {
 
     @Override
     public void read(JSONObject object) throws JSONException {
-        setTextAttachment(object.optString(TEXT_ATTACHMENT));
+        setTextAttachment(object.optString(TEXT_ATTACHMENT, null));
         if (object.has(BINARY_ATTACHMENT)) {
             ErrorBinaryAttachment binaryAttachment = new ErrorBinaryAttachment();
             binaryAttachment.read(object.getJSONObject(BINARY_ATTACHMENT));


### PR DESCRIPTION
When using only a binary attachment.