### PR TITLE
Truncate stack overflow error to avoid app from crashing forever

### DIFF
--- a/apps/sasquatch/src/main/AndroidManifest.xml
+++ b/apps/sasquatch/src/main/AndroidManifest.xml
@@ -18,6 +18,9 @@
             </intent-filter>
         </activity>
         <activity
+            android:name=".activities.CrashActivity"
+            android:label="@string/title_crashes" />
+        <activity
             android:name=".activities.DeviceInfoActivity"
             android:label="@string/title_device_info" />
         <activity

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/CrashActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/CrashActivity.java
@@ -1,0 +1,99 @@
+package com.microsoft.azure.mobile.sasquatch.activities;
+
+import android.os.Bundle;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.v7.app.AppCompatActivity;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.AdapterView;
+import android.widget.ArrayAdapter;
+import android.widget.ListView;
+import android.widget.TextView;
+
+import com.microsoft.azure.mobile.crashes.Crashes;
+import com.microsoft.azure.mobile.crashes.model.TestCrashException;
+import com.microsoft.azure.mobile.sasquatch.R;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class CrashActivity extends AppCompatActivity {
+
+    private final List<Crash> sCrashes = Arrays.asList(
+            new Crash(R.string.title_test_crash, R.string.description_test_crash, new Runnable() {
+
+                @Override
+                public void run() {
+                    Crashes.generateTestCrash();
+                    throw new TestCrashException();
+                }
+            }),
+            new Crash(R.string.title_crash_divide_by_0, R.string.title_crash_divide_by_0, new Runnable() {
+
+                @Override
+                @SuppressWarnings("ResultOfMethodCallIgnored")
+                public void run() {
+                    ("" + (42 / Integer.valueOf("0"))).toCharArray();
+                }
+            }),
+            new Crash(R.string.title_test_ui_crash, R.string.description_test_ui_crash, new Runnable() {
+
+                @Override
+                @SuppressWarnings("ResultOfMethodCallIgnored")
+                public void run() {
+                    ListView view = (ListView) findViewById(R.id.list);
+                    view.setAdapter(new ArrayAdapter<>(CrashActivity.this, android.R.layout.simple_list_item_2, sCrashes));
+                }
+            }),
+            new Crash(R.string.title_stack_overflow_crash, R.string.description_stack_overflow_crash, new Runnable() {
+
+                @SuppressWarnings("InfiniteRecursion")
+                @Override
+                public void run() {
+                    run();
+                }
+            })
+    );
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_list);
+
+        ListView listView = (ListView) findViewById(R.id.list);
+        listView.setAdapter(new ArrayAdapter<Crash>(this, android.R.layout.simple_list_item_2, android.R.id.text1, sCrashes) {
+
+            @SuppressWarnings("ConstantConditions")
+            @NonNull
+            @Override
+            public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
+                View view = super.getView(position, convertView, parent);
+                ((TextView) view.findViewById(android.R.id.text1)).setText(getItem(position).title);
+                ((TextView) view.findViewById(android.R.id.text2)).setText(getItem(position).description);
+                return view;
+            }
+        });
+        listView.setOnItemClickListener(new AdapterView.OnItemClickListener() {
+
+            @Override
+            public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
+                ((Crash) parent.getItemAtPosition(position)).crashTask.run();
+            }
+        });
+    }
+
+    private static class Crash {
+        final int title;
+
+        final int description;
+
+        final Runnable crashTask;
+
+        Crash(int title, int description, Runnable crashTask) {
+            this.title = title;
+            this.description = description;
+            this.crashTask = crashTask;
+        }
+    }
+}

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/ManagedErrorActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/ManagedErrorActivity.java
@@ -49,9 +49,9 @@ public class ManagedErrorActivity extends AppCompatActivity {
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
-        setContentView(R.layout.activity_managed_error);
+        setContentView(R.layout.activity_list);
 
-        ListView listView = (ListView) findViewById(R.id.throwables_list_view);
+        ListView listView = (ListView) findViewById(R.id.list);
         listView.setAdapter(new ArrayAdapter<Class<? extends Throwable>>(this, android.R.layout.simple_list_item_1, sSupportedThrowables) {
             @SuppressWarnings("ConstantConditions")
             @NonNull

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/features/TestFeatures.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/features/TestFeatures.java
@@ -5,8 +5,8 @@ import android.content.Intent;
 import android.view.View;
 import android.widget.AdapterView;
 
-import com.microsoft.azure.mobile.crashes.Crashes;
 import com.microsoft.azure.mobile.sasquatch.R;
+import com.microsoft.azure.mobile.sasquatch.activities.CrashActivity;
 import com.microsoft.azure.mobile.sasquatch.activities.DeviceInfoActivity;
 import com.microsoft.azure.mobile.sasquatch.activities.DummyActivity;
 import com.microsoft.azure.mobile.sasquatch.activities.EventActivity;
@@ -24,29 +24,12 @@ public final class TestFeatures {
     public static void initialize(Activity parentActivity) {
         sTestFeatureModel = new ArrayList<>();
         sParentActivity = new WeakReference<>(parentActivity);
-        sTestFeatureModel.add(new TestFeatureModel(R.string.title_crash, R.string.description_crash, new View.OnClickListener() {
-
-            @Override
-            @SuppressWarnings({"ConstantConditions", "ResultOfMethodCallIgnored"})
-            public void onClick(View v) {
-
-                /* Make the app crash on purpose for testing report. */
-                Crashes.generateTestCrash();
-            }
-        }));
-        sTestFeatureModel.add(new TestFeatureModel(R.string.title_crash_2, R.string.description_crash_2, new View.OnClickListener() {
-
-            @Override
-            @SuppressWarnings({"ConstantConditions", "ResultOfMethodCallIgnored"})
-            public void onClick(View v) {
-                ("" + (42 / Integer.valueOf("0"))).toCharArray();
-            }
-        }));
+        sTestFeatureModel.add(new TestFeatureModel(R.string.title_crashes, R.string.description_crashes, CrashActivity.class));
         sTestFeatureModel.add(new TestFeatureModel(R.string.title_device_info, R.string.description_device_info, DeviceInfoActivity.class));
-        sTestFeatureModel.add(new TestFeatureModel(R.string.title_error, R.string.description_error, ManagedErrorActivity.class));
         sTestFeatureModel.add(new TestFeatureModel(R.string.title_event, R.string.description_event, EventActivity.class));
         sTestFeatureModel.add(new TestFeatureModel(R.string.title_page, R.string.description_page, PageActivity.class));
         sTestFeatureModel.add(new TestFeatureModel(R.string.title_generate_page_log, R.string.description_generate_page_log, DummyActivity.class));
+        sTestFeatureModel.add(new TestFeatureModel(R.string.title_error, R.string.description_error, ManagedErrorActivity.class));
     }
 
     public static List<TestFeatureModel> getAvailableControls() {

--- a/apps/sasquatch/src/main/res/layout/activity_list.xml
+++ b/apps/sasquatch/src/main/res/layout/activity_list.xml
@@ -1,16 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:paddingBottom="@dimen/activity_vertical_margin"
     android:paddingLeft="@dimen/activity_horizontal_margin"
     android:paddingRight="@dimen/activity_horizontal_margin"
-    android:paddingTop="@dimen/activity_vertical_margin"
-    tools:context=".activities.ManagedErrorActivity">
+    android:paddingTop="@dimen/activity_vertical_margin">
 
     <ListView
-        android:id="@+id/throwables_list_view"
+        android:id="@+id/list"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
 </LinearLayout>

--- a/apps/sasquatch/src/main/res/values/crashes.xml
+++ b/apps/sasquatch/src/main/res/values/crashes.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="title_test_crash">Test crash</string>
+    <string name="description_test_crash">Using Crash.generateTestCrash() API</string>
+    <string name="title_crash_divide_by_0">Device by 0</string>
+    <string name="title_test_ui_crash">Test some UI crash</string>
+    <string name="description_test_ui_crash">A UI coding mistake, has inner exception</string>
+    <string name="title_stack_overflow_crash">Stack overflow crash</string>
+    <string name="description_stack_overflow_crash">Caused by infinite recursion</string>
+    <string name="crash_confirmation_dialog_title">Unexpected crash found</string>
+    <string name="crash_confirmation_dialog_message">Would you like to send an anonymous report so we can fix the problem?</string>
+    <string name="crash_confirmation_dialog_not_send_button">Don\'t Send</string>
+    <string name="crash_confirmation_dialog_always_send_button">Always Send</string>
+    <string name="crash_confirmation_dialog_send_button">Send</string>
+    <string name="crash_before_sending">Sending Crash reports.</string>
+    <string name="crash_sent_succeeded">Crash reports delivered successfully.</string>
+    <string name="crash_sent_failed">Failed to deliver Crash reports.</string>
+</resources>

--- a/apps/sasquatch/src/main/res/values/strings.xml
+++ b/apps/sasquatch/src/main/res/values/strings.xml
@@ -4,10 +4,8 @@
     <string name="app_name_jcenter">Sasquatch</string>
     <string name="sdk_source_format">SDK source: %s</string>
     <string name="settings">Settings</string>
-    <string name="title_crash">Crash me</string>
-    <string name="description_crash">generateTestCrashes</string>
-    <string name="title_crash_2">Crash me</string>
-    <string name="description_crash_2">Divide 42 by 0</string>
+    <string name="title_crashes">Crashes</string>
+    <string name="description_crashes">Test crashes</string>
     <string name="title_device_info">Device info</string>
     <string name="description_device_info">Display device information</string>
     <string name="title_generate_page_log">Generate page logs</string>
@@ -25,12 +23,4 @@
     <string name="key">Key</string>
     <string name="value">Value</string>
     <string name="app_secret_toast">App Secret: %s</string>
-    <string name="crash_confirmation_dialog_title">Unexpected crash found</string>
-    <string name="crash_confirmation_dialog_message">Would you like to send an anonymous report so we can fix the problem?</string>
-    <string name="crash_confirmation_dialog_not_send_button">Don\'t Send</string>
-    <string name="crash_confirmation_dialog_always_send_button">Always Send</string>
-    <string name="crash_confirmation_dialog_send_button">Send</string>
-    <string name="crash_before_sending">Sending Crash reports.</string>
-    <string name="crash_sent_succeeded">Crash reports delivered successfully.</string>
-    <string name="crash_sent_failed">Failed to deliver Crash reports.</string>
 </resources>

--- a/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/CrashesAndroidTest.java
+++ b/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/CrashesAndroidTest.java
@@ -79,7 +79,7 @@ public class CrashesAndroidTest {
         when(crashesListener.shouldProcess(any(ErrorReport.class))).thenReturn(true);
         when(crashesListener.shouldAwaitUserConfirmation()).thenReturn(true);
         Crashes.setListener(crashesListener);
-        final RuntimeException exception = new RuntimeException();
+        final Error exception = generateStackOverflowError();
         final Thread thread = new Thread() {
 
             @Override
@@ -147,6 +147,21 @@ public class CrashesAndroidTest {
         verify(crashesListener).onBeforeSending(any(ErrorReport.class));
         verify(crashesListener).onSendingSucceeded(any(ErrorReport.class));
         verifyNoMoreInteractions(crashesListener);
+
+        /* Verify log was truncated to 256 frames. */
+        assertTrue(log.get() instanceof ManagedErrorLog);
+        ManagedErrorLog errorLog = (ManagedErrorLog) log.get();
+        assertNotNull(errorLog.getException());
+        assertNotNull(errorLog.getException().getFrames());
+        assertEquals(ErrorLogHelper.FRAME_LIMIT, errorLog.getException().getFrames().size());
+    }
+
+    private Error generateStackOverflowError() {
+        try {
+            return generateStackOverflowError();
+        } catch (StackOverflowError error) {
+            return error;
+        }
     }
 
     @Test

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/utils/ErrorLogHelper.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/utils/ErrorLogHelper.java
@@ -36,16 +36,28 @@ import java.util.UUID;
  */
 public class ErrorLogHelper {
 
+    /**
+     * Error log file extension for the JSON schema.
+     */
     public static final String ERROR_LOG_FILE_EXTENSION = ".json";
 
+    /**
+     * Error log file extension for the serialized throwable for client side inspection.
+     */
     public static final String THROWABLE_FILE_EXTENSION = ".throwable";
+
     /**
      * For huge stack traces such as giant StackOverflowError, we keep only beginning and end of frames according to this limit.
      */
     @VisibleForTesting
     public static final int FRAME_LIMIT = 256;
+
+    /**
+     * Error log directory within application files.
+     */
     @VisibleForTesting
     static final String ERROR_DIRECTORY = "error";
+
     /**
      * We keep the first half of the limit of frames from the beginning and the second half from end.
      */

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/utils/ErrorLogHelper.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/utils/ErrorLogHelper.java
@@ -9,6 +9,7 @@ import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
+import android.util.Log;
 
 import com.microsoft.azure.mobile.Constants;
 import com.microsoft.azure.mobile.crashes.Crashes;
@@ -42,6 +43,17 @@ public class ErrorLogHelper {
 
     @VisibleForTesting
     static final String ERROR_DIRECTORY = "error";
+
+    /**
+     * For huge stack traces such as giant StackOverflowError, we keep only beginning and end of frames according to this limit.
+     */
+    @VisibleForTesting
+    public static final int FRAME_LIMIT = 256;
+
+    /**
+     * We keep the first half of the limit of frames from the beginning and the second half from end.
+     */
+    private static final int FRAME_LIMIT_HALF = FRAME_LIMIT / 2;
 
     /**
      * Root directory for error log and throwable files.
@@ -229,14 +241,29 @@ public class ErrorLogHelper {
     @NonNull
     private static List<StackFrame> getModelFramesFromStackTrace(@NonNull StackTraceElement[] stackTrace) {
         List<StackFrame> stackFrames = new ArrayList<>();
-        for (StackTraceElement stackTraceElement : stackTrace) {
-            StackFrame stackFrame = new StackFrame();
-            stackFrame.setClassName(stackTraceElement.getClassName());
-            stackFrame.setMethodName(stackTraceElement.getMethodName());
-            stackFrame.setLineNumber(stackTraceElement.getLineNumber());
-            stackFrame.setFileName(stackTraceElement.getFileName());
-            stackFrames.add(stackFrame);
+        if (stackTrace.length > FRAME_LIMIT) {
+            for (int i = 0; i < FRAME_LIMIT_HALF; i++) {
+                stackFrames.add(getModelStackFrame(stackTrace[i]));
+            }
+            for (int i = stackTrace.length - FRAME_LIMIT_HALF; i < stackTrace.length; i++) {
+                stackFrames.add(getModelStackFrame(stackTrace[i]));
+            }
+            Log.w(Crashes.LOG_TAG, "Crash frames truncated from " + stackTrace.length + " to " + stackFrames.size() + " frames.");
+        } else {
+            for (StackTraceElement stackTraceElement : stackTrace) {
+                stackFrames.add(getModelStackFrame(stackTraceElement));
+            }
         }
         return stackFrames;
+    }
+
+    @NonNull
+    private static StackFrame getModelStackFrame(StackTraceElement stackTraceElement) {
+        StackFrame stackFrame = new StackFrame();
+        stackFrame.setClassName(stackTraceElement.getClassName());
+        stackFrame.setMethodName(stackTraceElement.getMethodName());
+        stackFrame.setLineNumber(stackTraceElement.getLineNumber());
+        stackFrame.setFileName(stackTraceElement.getFileName());
+        return stackFrame;
     }
 }

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/utils/ErrorLogHelper.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/utils/ErrorLogHelper.java
@@ -9,7 +9,6 @@ import android.os.SystemClock;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
-import android.util.Log;
 
 import com.microsoft.azure.mobile.Constants;
 import com.microsoft.azure.mobile.crashes.Crashes;
@@ -40,16 +39,13 @@ public class ErrorLogHelper {
     public static final String ERROR_LOG_FILE_EXTENSION = ".json";
 
     public static final String THROWABLE_FILE_EXTENSION = ".throwable";
-
-    @VisibleForTesting
-    static final String ERROR_DIRECTORY = "error";
-
     /**
      * For huge stack traces such as giant StackOverflowError, we keep only beginning and end of frames according to this limit.
      */
     @VisibleForTesting
     public static final int FRAME_LIMIT = 256;
-
+    @VisibleForTesting
+    static final String ERROR_DIRECTORY = "error";
     /**
      * We keep the first half of the limit of frames from the beginning and the second half from end.
      */
@@ -248,7 +244,7 @@ public class ErrorLogHelper {
             for (int i = stackTrace.length - FRAME_LIMIT_HALF; i < stackTrace.length; i++) {
                 stackFrames.add(getModelStackFrame(stackTrace[i]));
             }
-            Log.w(Crashes.LOG_TAG, "Crash frames truncated from " + stackTrace.length + " to " + stackFrames.size() + " frames.");
+            MobileCenterLog.warn(Crashes.LOG_TAG, "Crash frames truncated from " + stackTrace.length + " to " + stackFrames.size() + " frames.");
         } else {
             for (StackTraceElement stackTraceElement : stackTrace) {
                 stackFrames.add(getModelStackFrame(stackTraceElement));


### PR DESCRIPTION
Keep 128 first frames and 128 last frames for huge exceptions.
Add that test in sasquatch and integration test.