### PR TITLE
Team decided to do a breaking change in getErrorReport

### DIFF
--- a/apps/sasquatch/src/jcenterDependency/java/com/microsoft/azure/mobile/analytics/mobile/sasquatch/features/GetLastSessionErrorReportFeatureTest.java
+++ b/apps/sasquatch/src/jcenterDependency/java/com/microsoft/azure/mobile/analytics/mobile/sasquatch/features/GetLastSessionErrorReportFeatureTest.java
@@ -1,0 +1,18 @@
+package com.microsoft.azure.mobile.analytics.mobile.sasquatch.features;
+
+import android.util.Log;
+
+import com.microsoft.azure.mobile.crashes.Crashes;
+import com.microsoft.azure.mobile.crashes.model.ErrorReport;
+
+import static com.microsoft.azure.mobile.sasquatch.activities.MainActivity.LOG_TAG;
+
+public class GetLastSessionErrorReportFeatureTest {
+
+    public static void run() {
+        ErrorReport lastSessionCrashReport = Crashes.getLastSessionCrashReport();
+        if (lastSessionCrashReport != null) {
+            Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getThrowable()=", lastSessionCrashReport.getThrowable());
+        }
+    }
+}

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/MainActivity.java
@@ -6,7 +6,6 @@ import android.content.Intent;
 import android.content.SharedPreferences;
 import android.os.Bundle;
 import android.os.StrictMode;
-import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -17,8 +16,8 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.microsoft.azure.mobile.MobileCenter;
-import com.microsoft.azure.mobile.ResultCallback;
 import com.microsoft.azure.mobile.analytics.Analytics;
+import com.microsoft.azure.mobile.analytics.mobile.sasquatch.features.GetLastSessionErrorReportFeatureTest;
 import com.microsoft.azure.mobile.crashes.AbstractCrashesListener;
 import com.microsoft.azure.mobile.crashes.Crashes;
 import com.microsoft.azure.mobile.crashes.ErrorAttachments;
@@ -31,12 +30,10 @@ import com.microsoft.azure.mobile.sasquatch.features.TestFeaturesListAdapter;
 
 public class MainActivity extends AppCompatActivity {
 
+    public static final String LOG_TAG = "MobileCenterSasquatch";
     static final String APP_SECRET = "45d1d9f6-2492-4e68-bd44-7190351eb5f3";
     static final String APP_SECRET_KEY = "appSecret";
     static final String SERVER_URL_KEY = "serverUrl";
-
-    private static final String LOG_TAG = "MobileCenterSasquatch";
-
     static SharedPreferences sSharedPreferences;
 
     @Override
@@ -56,15 +53,7 @@ public class MainActivity extends AppCompatActivity {
         MobileCenter.start(getApplication(), getAppSecret(), Analytics.class, Crashes.class);
 
         Log.i(LOG_TAG, "Crashes.hasCrashedInLastSession=" + Crashes.hasCrashedInLastSession());
-        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
-
-            @Override
-            public void onResult(@Nullable ErrorReport data) {
-                if (data != null) {
-                    Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getThrowable()=", data.getThrowable());
-                }
-            }
-        });
+        GetLastSessionErrorReportFeatureTest.run();
 
         ((TextView) findViewById(R.id.package_name)).setText(String.format(getString(R.string.sdk_source_format), getPackageName().substring(getPackageName().lastIndexOf(".") + 1)));
         TestFeatures.initialize(this);

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/MainActivity.java
@@ -4,9 +4,9 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
-import android.os.AsyncTask;
 import android.os.Bundle;
 import android.os.StrictMode;
+import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
 import android.util.Log;
@@ -17,6 +17,7 @@ import android.widget.TextView;
 import android.widget.Toast;
 
 import com.microsoft.azure.mobile.MobileCenter;
+import com.microsoft.azure.mobile.ResultCallback;
 import com.microsoft.azure.mobile.analytics.Analytics;
 import com.microsoft.azure.mobile.crashes.AbstractCrashesListener;
 import com.microsoft.azure.mobile.crashes.Crashes;
@@ -55,16 +56,15 @@ public class MainActivity extends AppCompatActivity {
         MobileCenter.start(getApplication(), getAppSecret(), Analytics.class, Crashes.class);
 
         Log.i(LOG_TAG, "Crashes.hasCrashedInLastSession=" + Crashes.hasCrashedInLastSession());
-        new AsyncTask<Void, Void, Void>() {
+        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
+
             @Override
-            protected Void doInBackground(Void[] params) {
-                ErrorReport lastSessionCrashReport = Crashes.getLastSessionCrashReport();
-                if (lastSessionCrashReport != null) {
-                    Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getThrowable()=", lastSessionCrashReport.getThrowable());
+            public void onResult(@Nullable ErrorReport data) {
+                if (data != null) {
+                    Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getThrowable()=", data.getThrowable());
                 }
-                return null;
             }
-        }.execute();
+        });
 
         ((TextView) findViewById(R.id.package_name)).setText(String.format(getString(R.string.sdk_source_format), getPackageName().substring(getPackageName().lastIndexOf(".") + 1)));
         TestFeatures.initialize(this);

--- a/apps/sasquatch/src/projectDependency/java/com/microsoft/azure/mobile/analytics/mobile/sasquatch/features/GetLastSessionErrorReportFeatureTest.java
+++ b/apps/sasquatch/src/projectDependency/java/com/microsoft/azure/mobile/analytics/mobile/sasquatch/features/GetLastSessionErrorReportFeatureTest.java
@@ -1,0 +1,25 @@
+package com.microsoft.azure.mobile.analytics.mobile.sasquatch.features;
+
+import android.support.annotation.Nullable;
+import android.util.Log;
+
+import com.microsoft.azure.mobile.ResultCallback;
+import com.microsoft.azure.mobile.crashes.Crashes;
+import com.microsoft.azure.mobile.crashes.model.ErrorReport;
+
+import static com.microsoft.azure.mobile.sasquatch.activities.MainActivity.LOG_TAG;
+
+public class GetLastSessionErrorReportFeatureTest {
+
+    public static void run() {
+        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
+
+            @Override
+            public void onResult(@Nullable ErrorReport data) {
+                if (data != null) {
+                    Log.i(LOG_TAG, "Crashes.getLastSessionCrashReport().getThrowable()=", data.getThrowable());
+                }
+            }
+        });
+    }
+}

--- a/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/CrashesAndroidTest.java
+++ b/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/CrashesAndroidTest.java
@@ -148,7 +148,7 @@ public class CrashesAndroidTest {
 
         /* Check last session error report. */
         assertTrue(Crashes.hasCrashedInLastSession());
-        Crashes.getLastSessionCrashReportAsync(new ResultCallback<ErrorReport>() {
+        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
 
             @Override
             public void onResult(ErrorReport errorReport) {
@@ -193,7 +193,7 @@ public class CrashesAndroidTest {
         Crashes.getInstance().onChannelReady(sContext, channel);
         waitForCrashesHandlerTasksToComplete();
         assertFalse(Crashes.hasCrashedInLastSession());
-        Crashes.getLastSessionCrashReportAsync(new ResultCallback<ErrorReport>() {
+        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
 
             @Override
             public void onResult(ErrorReport errorReport) {
@@ -277,7 +277,7 @@ public class CrashesAndroidTest {
         Crashes.unsetInstance();
         Crashes.getInstance().onChannelReady(sContext, channel);
         waitForCrashesHandlerTasksToComplete();
-        Crashes.getLastSessionCrashReportAsync(new ResultCallback<ErrorReport>() {
+        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
 
             @Override
             public void onResult(ErrorReport errorReport) {

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/Crashes.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/Crashes.java
@@ -263,14 +263,14 @@ public class Crashes extends AbstractMobileCenterService {
     /**
      * Provides information about any available crash report from the last session, if it crashed.
      * This method is a synchronous call and blocks caller thread.
-     * Use {@link #getLastSessionCrashReportAsync(ResultCallback)} for asynchronous call.
+     * Use {@link #getLastSessionCrashReport(ResultCallback)} for asynchronous call.
      *
      * @return The crash report from the last session if one was set.
-     * @see #getLastSessionCrashReportAsync(ResultCallback)
+     * @see #getLastSessionCrashReport(ResultCallback)
      */
     @Nullable
     @WorkerThread
-    public static ErrorReport getLastSessionCrashReport() {
+    static ErrorReport getLastSessionCrashReport() {
         return getInstance().getInstanceLastSessionCrashReport();
     }
 
@@ -279,8 +279,8 @@ public class Crashes extends AbstractMobileCenterService {
      *
      * @param callback The callback that will receive crash in the last session.
      */
-    public static void getLastSessionCrashReportAsync(ResultCallback<ErrorReport> callback) {
-        getInstance().getInstanceLastSessionCrashReportAsync(callback);
+    public static void getLastSessionCrashReport(ResultCallback<ErrorReport> callback) {
+        getInstance().getInstanceLastSessionCrashReport(callback);
     }
 
     /**
@@ -306,9 +306,9 @@ public class Crashes extends AbstractMobileCenterService {
     }
 
     /**
-     * Implements {@link #getLastSessionCrashReportAsync(ResultCallback)} at instance level.
+     * Implements {@link #getLastSessionCrashReport(ResultCallback)} at instance level.
      */
-    private synchronized void getInstanceLastSessionCrashReportAsync(final ResultCallback<ErrorReport> callback) {
+    private synchronized void getInstanceLastSessionCrashReport(final ResultCallback<ErrorReport> callback) {
         if (mCountDownLatch == null || mCountDownLatch.getCount() <= 0)
             HandlerUtils.runOnUiThread(new Runnable() {
 

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/CrashesTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/CrashesTest.java
@@ -865,10 +865,10 @@ public class CrashesTest {
             }
         };
 
-        Crashes.getLastSessionCrashReportAsync(callback);
+        Crashes.getLastSessionCrashReport(callback);
         Crashes.getInstance().onChannelReady(mock(Context.class), mock(Channel.class));
         assertFalse(Crashes.hasCrashedInLastSession());
-        Crashes.getLastSessionCrashReportAsync(callback);
+        Crashes.getLastSessionCrashReport(callback);
     }
 
     @Test
@@ -911,8 +911,8 @@ public class CrashesTest {
             public String answer(InvocationOnMock invocation) throws Throwable {
 
                 /* Call twice for multiple listeners during initialize. */
-                Crashes.getLastSessionCrashReportAsync(callback);
-                Crashes.getLastSessionCrashReportAsync(callback);
+                Crashes.getLastSessionCrashReport(callback);
+                Crashes.getLastSessionCrashReport(callback);
                 return "";
             }
         });
@@ -930,7 +930,7 @@ public class CrashesTest {
 
         assertTrue(Crashes.hasCrashedInLastSession());
 
-        Crashes.getLastSessionCrashReportAsync(new ResultCallback<ErrorReport>() {
+        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
 
             @Override
             public void onResult(ErrorReport errorReport) {
@@ -954,7 +954,7 @@ public class CrashesTest {
         Crashes.setEnabled(false);
 
         assertFalse(Crashes.hasCrashedInLastSession());
-        Crashes.getLastSessionCrashReportAsync(new ResultCallback<ErrorReport>() {
+        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
 
             @Override
             public void onResult(ErrorReport data) {
@@ -997,11 +997,11 @@ public class CrashesTest {
          * Here the service is enabled by default but we are waiting channel to be ready, simulate that.
          */
         assertTrue(Crashes.isEnabled());
-        Crashes.getLastSessionCrashReportAsync(callback);
+        Crashes.getLastSessionCrashReport(callback);
         Crashes.getInstance().onChannelReady(mock(Context.class), mock(Channel.class));
 
         assertFalse(Crashes.hasCrashedInLastSession());
-        Crashes.getLastSessionCrashReportAsync(callback);
+        Crashes.getLastSessionCrashReport(callback);
 
         /*
          * De-serializing fails twice: processing the log from last time as part of the bulk processing.
@@ -1019,7 +1019,7 @@ public class CrashesTest {
         when(ErrorLogHelper.getLastErrorLogFile()).thenReturn(file);
         Crashes.getInstance().onChannelReady(mock(Context.class), mock(Channel.class));
         assertFalse(Crashes.hasCrashedInLastSession());
-        Crashes.getLastSessionCrashReportAsync(new ResultCallback<ErrorReport>() {
+        Crashes.getLastSessionCrashReport(new ResultCallback<ErrorReport>() {
 
             @Override
             public void onResult(ErrorReport data) {
@@ -1043,8 +1043,8 @@ public class CrashesTest {
         };
 
         /* Call twice for multiple callbacks before initialize. */
-        Crashes.getLastSessionCrashReportAsync(callback);
-        Crashes.getLastSessionCrashReportAsync(callback);
+        Crashes.getLastSessionCrashReport(callback);
+        Crashes.getLastSessionCrashReport(callback);
         Crashes.getInstance().onChannelReady(mock(Context.class), mock(Channel.class));
         assertFalse(Crashes.hasCrashedInLastSession());
     }


### PR DESCRIPTION
The sync version is no longer available as a public method, and the async method loses its suffix.