### PR TITLE
Shutdown channel on uncaught exception without Crashes module

### DIFF
--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/Crashes.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/Crashes.java
@@ -794,10 +794,6 @@ public class Crashes extends AbstractMobileCenterService {
         } catch (IOException e) {
             MobileCenterLog.error(Crashes.LOG_TAG, "Error writing error log to file", e);
         }
-
-        /* Wait channel to finish saving other logs in background. */
-        if (mChannel != null)
-            mChannel.shutdown();
     }
 
     /**

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandler.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandler.java
@@ -1,7 +1,8 @@
 package com.microsoft.azure.mobile.crashes;
 
-import android.os.Process;
 import android.support.annotation.VisibleForTesting;
+
+import com.microsoft.azure.mobile.utils.ShutdownHelper;
 
 class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
 
@@ -20,7 +21,7 @@ class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
             if (mDefaultUncaughtExceptionHandler != null) {
                 mDefaultUncaughtExceptionHandler.uncaughtException(thread, exception);
             } else {
-                ShutdownHelper.shutdown();
+                ShutdownHelper.shutdown(10);
             }
         }
     }
@@ -49,14 +50,5 @@ class UncaughtExceptionHandler implements Thread.UncaughtExceptionHandler {
 
     void unregister() {
         Thread.setDefaultUncaughtExceptionHandler(mDefaultUncaughtExceptionHandler);
-    }
-
-    @VisibleForTesting
-    static class ShutdownHelper {
-
-        static void shutdown() {
-            Process.killProcess(Process.myPid());
-            System.exit(10);
-        }
     }
 }

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
@@ -48,7 +48,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @SuppressWarnings("unused")
-@PrepareForTest({SystemClock.class, StorageHelper.PreferencesStorage.class, StorageHelper.InternalStorage.class, Crashes.class, ErrorLogHelper.class, DeviceInfoHelper.class, ShutdownHelper.class, MobileCenterLog.class, Process.class})
+@PrepareForTest({SystemClock.class, StorageHelper.PreferencesStorage.class, StorageHelper.InternalStorage.class, Crashes.class, ErrorLogHelper.class, DeviceInfoHelper.class, ShutdownHelper.class, MobileCenterLog.class})
 public class UncaughtExceptionHandlerTest {
 
     private static final String CRASHES_ENABLED_KEY = PrefStorageConstants.KEY_ENABLED + "_" + Crashes.getInstance().getGroupName();
@@ -69,7 +69,6 @@ public class UncaughtExceptionHandlerTest {
         mockStatic(StorageHelper.InternalStorage.class);
         mockStatic(ErrorLogHelper.class);
         mockStatic(DeviceInfoHelper.class);
-        mockStatic(Process.class);
         mockStatic(System.class);
 
         when(StorageHelper.PreferencesStorage.getBoolean(CRASHES_ENABLED_KEY, true)).thenReturn(true);
@@ -137,9 +136,6 @@ public class UncaughtExceptionHandlerTest {
     @Test
     public void handleExceptionAndIgnoreDefaultHandler() {
 
-        /* Mock process id */
-        when(Process.myPid()).thenReturn(123);
-
         /* Register crash handler */
         mExceptionHandler.register();
 
@@ -152,8 +148,6 @@ public class UncaughtExceptionHandlerTest {
 
         verifyStatic();
         ErrorLogHelper.createErrorLog(any(Context.class), any(Thread.class), any(Throwable.class), Matchers.<Map<Thread, StackTraceElement[]>>any(), anyLong(), anyBoolean());
-        verifyStatic();
-        Process.killProcess(123);
         verifyStatic();
         System.exit(10);
     }

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.mobile.ingestion.models.json.LogSerializer;
 import com.microsoft.azure.mobile.utils.DeviceInfoHelper;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
 import com.microsoft.azure.mobile.utils.PrefStorageConstants;
+import com.microsoft.azure.mobile.utils.ShutdownHelper;
 import com.microsoft.azure.mobile.utils.storage.StorageHelper;
 
 import org.json.JSONException;
@@ -47,7 +48,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
 @SuppressWarnings("unused")
-@PrepareForTest({SystemClock.class, StorageHelper.PreferencesStorage.class, StorageHelper.InternalStorage.class, Crashes.class, ErrorLogHelper.class, DeviceInfoHelper.class, UncaughtExceptionHandler.ShutdownHelper.class, MobileCenterLog.class, Process.class})
+@PrepareForTest({SystemClock.class, StorageHelper.PreferencesStorage.class, StorageHelper.InternalStorage.class, Crashes.class, ErrorLogHelper.class, DeviceInfoHelper.class, ShutdownHelper.class, MobileCenterLog.class, Process.class})
 public class UncaughtExceptionHandlerTest {
 
     private static final String CRASHES_ENABLED_KEY = PrefStorageConstants.KEY_ENABLED + "_" + Crashes.getInstance().getGroupName();
@@ -134,8 +135,6 @@ public class UncaughtExceptionHandlerTest {
     @Test
     public void handleExceptionAndIgnoreDefaultHandler() {
 
-        // dummy coverage
-        new UncaughtExceptionHandler.ShutdownHelper();
 
         // mock process id
         when(Process.myPid()).thenReturn(123);

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
@@ -1,7 +1,6 @@
 package com.microsoft.azure.mobile.crashes;
 
 import android.content.Context;
-import android.os.Process;
 import android.os.SystemClock;
 
 import com.microsoft.azure.mobile.crashes.ingestion.models.ManagedErrorLog;

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
@@ -102,10 +102,12 @@ public class UncaughtExceptionHandlerTest {
 
     @Test
     public void registerWorks() {
-        // Verify that exception handler is default
+
+        /* Verify that exception handler is default */
         assertEquals(mDefaultExceptionHandler, Thread.getDefaultUncaughtExceptionHandler());
         mExceptionHandler.register();
-        // Verify that creation registers handler and previously defined handler is correctly saved
+
+        /* Verify that creation registers handler and previously defined handler is correctly saved */
         assertEquals(mExceptionHandler, Thread.getDefaultUncaughtExceptionHandler());
         assertEquals(mDefaultExceptionHandler, mExceptionHandler.getDefaultUncaughtExceptionHandler());
 
@@ -135,14 +137,13 @@ public class UncaughtExceptionHandlerTest {
     @Test
     public void handleExceptionAndIgnoreDefaultHandler() {
 
-
-        // mock process id
+        /* Mock process id */
         when(Process.myPid()).thenReturn(123);
 
-        // Register crash handler
+        /* Register crash handler */
         mExceptionHandler.register();
 
-        // Verify that the exception is handled and not being passed on to the previous default UncaughtExceptionHandler
+        /* Verify that the exception is handled and not being passed on to the previous default UncaughtExceptionHandler */
         Thread thread = Thread.currentThread();
         RuntimeException exception = new RuntimeException();
         mExceptionHandler.setIgnoreDefaultExceptionHandler(true);
@@ -159,7 +160,7 @@ public class UncaughtExceptionHandlerTest {
 
     @Test
     public void passDefaultHandler() {
-        // Verify that when crashes is disabled, an exception is instantly passed on
+        /* Verify that when crashes is disabled, an exception is instantly passed on */
         when(Crashes.isEnabled()).thenReturn(false);
 
         mExceptionHandler.register();
@@ -175,7 +176,7 @@ public class UncaughtExceptionHandlerTest {
 
     @Test
     public void crashesDisabledNoDefaultHandler() {
-        // Verify that when crashes is disabled, an exception is instantly passed on
+        /* Verify that when crashes is disabled, an exception is instantly passed on */
         when(Crashes.isEnabled()).thenReturn(false);
 
         mExceptionHandler.register();

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/MobileCenter.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/MobileCenter.java
@@ -439,6 +439,11 @@ public class MobileCenter {
     }
 
     @VisibleForTesting
+    UncaughtExceptionHandler getUncaughtExceptionHandler() {
+        return mUncaughtExceptionHandler;
+    }
+
+    @VisibleForTesting
     void setChannel(Channel channel) {
         mChannel = channel;
     }

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/MobileCenter.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/MobileCenter.java
@@ -57,6 +57,9 @@ public class MobileCenter {
      */
     private Application mApplication;
 
+    /**
+     * Handler for uncaught exceptions.
+     */
     private UncaughtExceptionHandler mUncaughtExceptionHandler;
 
     /**
@@ -294,7 +297,7 @@ public class MobileCenter {
             /* If parameters are valid, init context related resources. */
             StorageHelper.initialize(application);
 
-            /* For don't call PreferencesStorage twice. */
+            /* Remember state to avoid double call PreferencesStorage. */
             boolean enabled = isInstanceEnabled();
 
             /* Init uncaught exception handler. */
@@ -456,6 +459,7 @@ public class MobileCenter {
         @Override
         public void uncaughtException(Thread thread, Throwable exception) {
             if (isEnabled()) {
+
                 /* Wait channel to finish saving other logs in background. */
                 if (mChannel != null)
                     mChannel.shutdown();

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/utils/ShutdownHelper.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/utils/ShutdownHelper.java
@@ -13,10 +13,6 @@ public class ShutdownHelper {
         /* Hide constructor. */
     }
 
-    public static void shutdown() {
-        shutdown(1);
-    }
-
     public static void shutdown(int status) {
         Process.killProcess(Process.myPid());
         System.exit(status);

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/utils/ShutdownHelper.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/utils/ShutdownHelper.java
@@ -1,0 +1,18 @@
+package com.microsoft.azure.mobile.utils;
+
+import android.os.Process;
+
+/**
+ * Shutdown helper.
+ */
+public class ShutdownHelper {
+
+    public static void shutdown() {
+        shutdown(1);
+    }
+
+    public static void shutdown(int status) {
+        Process.killProcess(Process.myPid());
+        System.exit(status);
+    }
+}

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/utils/ShutdownHelper.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/utils/ShutdownHelper.java
@@ -1,11 +1,17 @@
 package com.microsoft.azure.mobile.utils;
 
 import android.os.Process;
+import android.support.annotation.VisibleForTesting;
 
 /**
  * Shutdown helper.
  */
 public class ShutdownHelper {
+
+    @VisibleForTesting
+    ShutdownHelper() {
+        /* Hide constructor. */
+    }
 
     public static void shutdown() {
         shutdown(1);

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/MobileCenterTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/MobileCenterTest.java
@@ -677,6 +677,7 @@ public class MobileCenterTest {
 
         when(Thread.getDefaultUncaughtExceptionHandler()).thenReturn(null);
         MobileCenter.setEnabled(true);
+        MobileCenter.getInstance().setChannel(null);
         assertNull(handler.getDefaultUncaughtExceptionHandler());
         handler.uncaughtException(thread, exception);
         verifyStatic();

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/MobileCenterTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/MobileCenterTest.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.mobile.ingestion.models.json.LogFactory;
 import com.microsoft.azure.mobile.utils.DeviceInfoHelper;
 import com.microsoft.azure.mobile.utils.IdHelper;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
+import com.microsoft.azure.mobile.utils.ShutdownHelper;
 import com.microsoft.azure.mobile.utils.storage.StorageHelper;
 
 import org.junit.After;
@@ -58,7 +59,20 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @SuppressWarnings("unused")
-@PrepareForTest({MobileCenter.class, Channel.class, Constants.class, MobileCenterLog.class, StorageHelper.class, StorageHelper.PreferencesStorage.class, IdHelper.class, StorageHelper.DatabaseStorage.class, DeviceInfoHelper.class})
+@PrepareForTest({
+        MobileCenter.class,
+        MobileCenter.UncaughtExceptionHandler.class,
+        Channel.class,
+        Constants.class,
+        MobileCenterLog.class,
+        StorageHelper.class,
+        StorageHelper.PreferencesStorage.class,
+        IdHelper.class,
+        StorageHelper.DatabaseStorage.class,
+        DeviceInfoHelper.class,
+        Thread.class,
+        ShutdownHelper.class
+})
 public class MobileCenterTest {
 
     private static final String DUMMY_APP_SECRET = "123e4567-e89b-12d3-a456-426655440000";
@@ -86,6 +100,8 @@ public class MobileCenterTest {
         mockStatic(StorageHelper.PreferencesStorage.class);
         mockStatic(IdHelper.class);
         mockStatic(StorageHelper.DatabaseStorage.class);
+        mockStatic(Thread.class);
+        mockStatic(ShutdownHelper.class);
 
         /* First call to com.microsoft.azure.mobile.MobileCenter.isEnabled shall return true, initial state. */
         when(StorageHelper.PreferencesStorage.getBoolean(anyString(), eq(true))).thenReturn(true);
@@ -632,6 +648,39 @@ public class MobileCenterTest {
         logUrl = "http://mock2";
         MobileCenter.setLogUrl(logUrl);
         verify(channel).setLogUrl(logUrl);
+    }
+
+    @Test
+    public void uncaughtExceptionHandler() {
+        Thread.UncaughtExceptionHandler defaultUncaughtExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
+        when(Thread.getDefaultUncaughtExceptionHandler()).thenReturn(defaultUncaughtExceptionHandler);
+        MobileCenter.configure(application, DUMMY_APP_SECRET);
+        MobileCenter.UncaughtExceptionHandler handler = MobileCenter.getInstance().getUncaughtExceptionHandler();
+        assertNotNull(handler);
+        assertEquals(defaultUncaughtExceptionHandler, handler.getDefaultUncaughtExceptionHandler());
+        verifyStatic();
+        Thread.setDefaultUncaughtExceptionHandler(eq(handler));
+
+        Channel channel = mock(Channel.class);
+        Thread thread = mock(Thread.class);
+        Throwable exception = mock(Throwable.class);
+        MobileCenter.getInstance().setChannel(channel);
+        handler.uncaughtException(thread, exception);
+        verify(channel).shutdown();
+        verify(defaultUncaughtExceptionHandler).uncaughtException(eq(thread), eq(exception));
+
+        MobileCenter.setEnabled(false);
+        verifyStatic();
+        Thread.setDefaultUncaughtExceptionHandler(eq(defaultUncaughtExceptionHandler));
+        handler.uncaughtException(thread, exception);
+        verify(channel, times(1)).shutdown();
+
+        when(Thread.getDefaultUncaughtExceptionHandler()).thenReturn(null);
+        MobileCenter.setEnabled(true);
+        assertNull(handler.getDefaultUncaughtExceptionHandler());
+        handler.uncaughtException(thread, exception);
+        verifyStatic();
+        ShutdownHelper.shutdown(10);
     }
 
     private static class DummyService extends AbstractMobileCenterService {

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/utils/ShutdownHelperTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/utils/ShutdownHelperTest.java
@@ -41,6 +41,4 @@ public class ShutdownHelperTest {
         verifyStatic();
         System.exit(999);
     }
-
-
 }

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/utils/ShutdownHelperTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/utils/ShutdownHelperTest.java
@@ -1,0 +1,50 @@
+package com.microsoft.azure.mobile.utils;
+
+import android.os.Process;
+
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.powermock.core.classloader.annotations.PrepareForTest;
+import org.powermock.modules.junit4.rule.PowerMockRule;
+
+import static org.junit.Assert.assertNotNull;
+import static org.powermock.api.mockito.PowerMockito.mockStatic;
+import static org.powermock.api.mockito.PowerMockito.verifyStatic;
+import static org.powermock.api.mockito.PowerMockito.when;
+
+@SuppressWarnings("unused")
+@PrepareForTest({ShutdownHelper.class, Process.class})
+public class ShutdownHelperTest {
+
+    @Rule
+    public PowerMockRule mPowerMockRule = new PowerMockRule();
+
+    @Before
+    public void setUp() {
+        mockStatic(Process.class);
+        mockStatic(System.class);
+    }
+
+    @Test
+    public void shutdown() throws Exception {
+
+        /* Dummy coverage */
+        assertNotNull(new ShutdownHelper());
+
+        /* Mock process id */
+        when(Process.myPid()).thenReturn(123);
+
+        ShutdownHelper.shutdown();
+        verifyStatic();
+        Process.killProcess(123);
+        verifyStatic();
+        System.exit(1);
+
+        ShutdownHelper.shutdown(999);
+        verifyStatic();
+        System.exit(999);
+    }
+
+
+}

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/utils/ShutdownHelperTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/utils/ShutdownHelperTest.java
@@ -35,13 +35,9 @@ public class ShutdownHelperTest {
         /* Mock process id */
         when(Process.myPid()).thenReturn(123);
 
-        ShutdownHelper.shutdown();
+        ShutdownHelper.shutdown(999);
         verifyStatic();
         Process.killProcess(123);
-        verifyStatic();
-        System.exit(1);
-
-        ShutdownHelper.shutdown(999);
         verifyStatic();
         System.exit(999);
     }


### PR DESCRIPTION
Shutdown channel on uncaught exception moved form Crashes module to core.
It's important in case when Crashes module not used in user application.
- Remembering the previous uncaught exception handler for chain handlers
- Move ShutdownHelper class to core utils to not duplicate code
- Added unit tests for UncaughtExceptionHandler
- Added unit tests for ShutdownHelperTest
- Fixed comments style in UncaughtExceptionHandlerTest.java