### PR TITLE
Add exception cause check to improve recoverable detection

### DIFF
--- a/sdk/mobile-center/src/androidTest/java/com/microsoft/azure/mobile/ingestion/http/HttpUtilsAndroidTest.java
+++ b/sdk/mobile-center/src/androidTest/java/com/microsoft/azure/mobile/ingestion/http/HttpUtilsAndroidTest.java
@@ -3,6 +3,7 @@ package com.microsoft.azure.mobile.ingestion.http;
 import org.junit.Test;
 
 import java.io.EOFException;
+import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.MalformedURLException;
 import java.net.PortUnreachableException;
@@ -37,6 +38,8 @@ public class HttpUtilsAndroidTest {
         assertTrue(isRecoverableError(new UnknownHostException()));
         assertTrue(isRecoverableError(new RejectedExecutionException()));
         assertFalse(isRecoverableError(new MalformedURLException()));
+        assertFalse(isRecoverableError(new IOException()));
+        assertTrue(isRecoverableError(new IOException(new EOFException())));
         for (int i = 0; i <= 4; i++)
             assertTrue(isRecoverableError(new HttpException(500 + i)));
         for (int i = 2; i <= 6; i++)

--- a/sdk/mobile-center/src/androidTest/java/com/microsoft/azure/mobile/ingestion/http/HttpUtilsAndroidTest.java
+++ b/sdk/mobile-center/src/androidTest/java/com/microsoft/azure/mobile/ingestion/http/HttpUtilsAndroidTest.java
@@ -40,6 +40,7 @@ public class HttpUtilsAndroidTest {
         assertFalse(isRecoverableError(new MalformedURLException()));
         assertFalse(isRecoverableError(new IOException()));
         assertTrue(isRecoverableError(new IOException(new EOFException())));
+        assertFalse(isRecoverableError(new IOException(new Exception())));
         for (int i = 0; i <= 4; i++)
             assertTrue(isRecoverableError(new HttpException(500 + i)));
         for (int i = 2; i <= 6; i++)

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/ingestion/http/HttpUtils.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/ingestion/http/HttpUtils.java
@@ -57,6 +57,14 @@ public final class HttpUtils {
             if (type.isAssignableFrom(t.getClass()))
                 return true;
 
+        /* Check the cause. */
+        Throwable cause = t.getCause();
+        if (cause != null) {
+            for (Class<?> type : RECOVERABLE_EXCEPTIONS)
+                if (type.isAssignableFrom(cause.getClass()))
+                    return true;
+        }
+
         /* Check corner cases. */
         if (t instanceof SSLException) {
             String message = t.getMessage();


### PR DESCRIPTION
The error like 
```
java.io.IOException: unexpected end of stream
	...
Caused by: java.io.EOFException: \n not found
```
should be retryable, but before not detected as it.