### PR TITLE
Fix issues with AsyncTask.onPostExecute being called in wrong thread

### DIFF
--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/CheckDownloadTask.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/CheckDownloadTask.java
@@ -8,6 +8,7 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.os.Build;
 
+import com.microsoft.azure.mobile.utils.HandlerUtils;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
 import com.microsoft.azure.mobile.utils.storage.StorageHelper;
 
@@ -162,9 +163,17 @@ class CheckDownloadTask extends AsyncTask<Void, Void, DownloadProgress> {
     }
 
     @Override
-    protected void onPostExecute(DownloadProgress result) {
+    protected void onPostExecute(final DownloadProgress result) {
         if (result != null) {
-            Distribute.getInstance().updateProgressDialog(this, result);
+
+            /* onPostExecute is not always called on UI thread due to an old Android bug. */
+            HandlerUtils.runOnUiThread(new Runnable() {
+
+                @Override
+                public void run() {
+                    Distribute.getInstance().updateProgressDialog(CheckDownloadTask.this, result);
+                }
+            });
         }
     }
 

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -645,12 +645,20 @@ public class Distribute extends AbstractMobileCenterService {
         }, new ServiceCallback() {
 
             @Override
-            public void onCallSucceeded(String payload) {
-                try {
-                    handleApiCallSuccess(releaseCallId, payload, ReleaseDetails.parse(payload));
-                } catch (JSONException e) {
-                    onCallFailed(e);
-                }
+            public void onCallSucceeded(final String payload) {
+
+                /* onPostExecute is not always called on UI thread due to an old Android bug. */
+                HandlerUtils.runOnUiThread(new Runnable() {
+
+                    @Override
+                    public void run() {
+                        try {
+                            handleApiCallSuccess(releaseCallId, payload, ReleaseDetails.parse(payload));
+                        } catch (JSONException e) {
+                            onCallFailed(e);
+                        }
+                    }
+                });
             }
 
             @Override
@@ -1138,15 +1146,8 @@ public class Distribute extends AbstractMobileCenterService {
      */
     private synchronized void hideProgressDialog() {
         if (mProgressDialog != null) {
-            final Dialog progressDialog = mProgressDialog;
+            mProgressDialog.hide();
             mProgressDialog = null;
-            HandlerUtils.runOnUiThread(new Runnable() {
-
-                @Override
-                public void run() {
-                    progressDialog.hide();
-                }
-            });
             HandlerUtils.getMainHandler().removeCallbacksAndMessages(HANDLER_TOKEN_CHECK_PROGRESS);
         }
     }

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/AbstractDistributeTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/AbstractDistributeTest.java
@@ -11,6 +11,7 @@ import android.text.TextUtils;
 import android.widget.Toast;
 
 import com.microsoft.azure.mobile.MobileCenter;
+import com.microsoft.azure.mobile.utils.HandlerUtils;
 import com.microsoft.azure.mobile.utils.HashUtils;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
 import com.microsoft.azure.mobile.utils.NetworkStateHelper;
@@ -44,7 +45,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @SuppressWarnings({"WeakerAccess", "CanBeFinal"})
-@PrepareForTest({Distribute.class, PreferencesStorage.class, MobileCenterLog.class, MobileCenter.class, NetworkStateHelper.class, BrowserUtils.class, UUIDUtils.class, ReleaseDetails.class, TextUtils.class, CryptoUtils.class, InstallerUtils.class, Toast.class})
+@PrepareForTest({Distribute.class, PreferencesStorage.class, MobileCenterLog.class, MobileCenter.class, NetworkStateHelper.class, BrowserUtils.class, UUIDUtils.class, ReleaseDetails.class, TextUtils.class, CryptoUtils.class, InstallerUtils.class, Toast.class, HandlerUtils.class})
 public class AbstractDistributeTest {
 
     static final String TEST_HASH = HashUtils.sha256("com.contoso:1.2.3:6");
@@ -188,5 +189,17 @@ public class AbstractDistributeTest {
         /* Toast. */
         mockStatic(Toast.class);
         when(Toast.makeText(any(Context.class), anyInt(), anyInt())).thenReturn(mToast);
+
+        /* Mock Handler .*/
+        mockStatic(HandlerUtils.class);
+        doAnswer(new Answer<Void>() {
+
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                ((Runnable) invocation.getArguments()[0]).run();
+                return null;
+            }
+        }).when(HandlerUtils.class);
+        HandlerUtils.runOnUiThread(any(Runnable.class));
     }
 }

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DistributeMandatoryDownloadTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DistributeMandatoryDownloadTest.java
@@ -49,7 +49,7 @@ import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
-@PrepareForTest({SystemClock.class, HandlerUtils.class})
+@PrepareForTest(SystemClock.class)
 public class DistributeMandatoryDownloadTest extends AbstractDistributeAfterDownloadTest {
 
     @Mock
@@ -93,7 +93,6 @@ public class DistributeMandatoryDownloadTest extends AbstractDistributeAfterDown
         when(SystemClock.uptimeMillis()).thenReturn(1L);
 
         /* Mock Handler. */
-        mockStatic(HandlerUtils.class);
         when(mHandler.postAtTime(any(Runnable.class), eq(HANDLER_TOKEN_CHECK_PROGRESS), anyLong())).then(new Answer<Boolean>() {
 
             @Override
@@ -103,15 +102,6 @@ public class DistributeMandatoryDownloadTest extends AbstractDistributeAfterDown
             }
         });
         when(HandlerUtils.getMainHandler()).thenReturn(mHandler);
-        doAnswer(new Answer<Void>() {
-
-            @Override
-            public Void answer(InvocationOnMock invocation) throws Throwable {
-                ((Runnable) invocation.getArguments()[0]).run();
-                return null;
-            }
-        }).when(HandlerUtils.class);
-        HandlerUtils.runOnUiThread(any(Runnable.class));
 
         /* Set up common download test. */
         setUpDownload(true);

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/channel/DefaultChannel.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/channel/DefaultChannel.java
@@ -21,6 +21,7 @@ import com.microsoft.azure.mobile.persistence.DatabasePersistenceAsync.AbstractD
 import com.microsoft.azure.mobile.persistence.DatabasePersistenceAsync.DatabasePersistenceAsyncCallback;
 import com.microsoft.azure.mobile.persistence.Persistence;
 import com.microsoft.azure.mobile.utils.DeviceInfoHelper;
+import com.microsoft.azure.mobile.utils.HandlerUtils;
 import com.microsoft.azure.mobile.utils.IdHelper;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
 
@@ -367,7 +368,7 @@ public class DefaultChannel implements Channel {
         });
     }
 
-    private synchronized void triggerIngestion(final String batchId, final GroupState groupState, final int stateSnapshot, List<Log> batch) {
+    private synchronized void triggerIngestion(final String batchId, final GroupState groupState, final int stateSnapshot, final List<Log> batch) {
         if (batchId != null && checkStateDidNotChange(groupState, stateSnapshot)) {
 
             /* Call group listener before sending logs to ingestion service. */
@@ -384,22 +385,50 @@ public class DefaultChannel implements Channel {
             /* Remember this batch. */
             groupState.mSendingBatches.put(batchId, batch);
 
+            /*
+             * Due to bug on old Android versions (verified on 4.0.4),
+             * if we start an async task from here, i.e. the async persistence handler thread,
+             * we end up with AsyncTask configured with the wrong Handler to use for onPostExecute
+             * instead of using main thread as advertised in Javadoc (and its a static field there).
+             *
+             * Our SDK guards against an application that would make a first async task in non UI
+             * thread before SDK is initialized, but we should also avoid corrupting AsyncTask
+             * with our wrong handler to avoid creating bugs in the application code since we are
+             * a library.
+             *
+             * So make sure we execute the async task from UI thread to avoid any issue.
+             */
+            HandlerUtils.runOnUiThread(new Runnable() {
+
+                @Override
+                public void run() {
+                    sendLogs(groupState, stateSnapshot, batch, batchId);
+                }
+            });
+        }
+    }
+
+    /**
+     * Send logs.
+     */
+    private synchronized void sendLogs(final GroupState groupState, final int stateSnapshot, List<Log> batch, final String batchId) {
+        if (checkStateDidNotChange(groupState, stateSnapshot)) {
+
             /* Send logs. */
             LogContainer logContainer = new LogContainer();
             logContainer.setLogs(batch);
             mIngestion.sendAsync(mAppSecret, mInstallId, logContainer, new ServiceCallback() {
 
-                        @Override
-                        public void onCallSucceeded(String payload) {
-                            handleSendingSuccess(groupState, stateSnapshot, batchId);
-                        }
+                @Override
+                public void onCallSucceeded(String payload) {
+                    handleSendingSuccess(groupState, stateSnapshot, batchId);
+                }
 
-                        @Override
-                        public void onCallFailed(Exception e) {
-                            handleSendingFailure(groupState, stateSnapshot, batchId, e);
-                        }
-                    }
-            );
+                @Override
+                public void onCallFailed(Exception e) {
+                    handleSendingFailure(groupState, stateSnapshot, batchId, e);
+                }
+            });
 
             /* Check for more pending logs. */
             checkPendingLogs(groupState.mName);

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/channel/AbstractDefaultChannelTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/channel/AbstractDefaultChannelTest.java
@@ -10,6 +10,7 @@ import com.microsoft.azure.mobile.ingestion.models.Device;
 import com.microsoft.azure.mobile.ingestion.models.Log;
 import com.microsoft.azure.mobile.persistence.DatabasePersistenceAsync;
 import com.microsoft.azure.mobile.utils.DeviceInfoHelper;
+import com.microsoft.azure.mobile.utils.HandlerUtils;
 import com.microsoft.azure.mobile.utils.IdHelper;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
 import com.microsoft.azure.mobile.utils.UUIDUtils;
@@ -29,11 +30,12 @@ import static com.microsoft.azure.mobile.persistence.DatabasePersistenceAsync.TH
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.powermock.api.mockito.PowerMockito.doAnswer;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.whenNew;
 
 @SuppressWarnings("WeakerAccess")
-@PrepareForTest({DefaultChannel.class, IdHelper.class, DeviceInfoHelper.class, DatabasePersistenceAsync.class, MobileCenterLog.class})
+@PrepareForTest({DefaultChannel.class, IdHelper.class, DeviceInfoHelper.class, DatabasePersistenceAsync.class, MobileCenterLog.class, HandlerUtils.class})
 public class AbstractDefaultChannelTest {
 
     static final String TEST_GROUP = "group_test";
@@ -115,5 +117,15 @@ public class AbstractDefaultChannelTest {
                 return true;
             }
         });
+        mockStatic(HandlerUtils.class);
+        doAnswer(new Answer<Void>() {
+
+            @Override
+            public Void answer(InvocationOnMock invocation) throws Throwable {
+                ((Runnable) invocation.getArguments()[0]).run();
+                return null;
+            }
+        }).when(HandlerUtils.class);
+        HandlerUtils.runOnUiThread(any(Runnable.class));
     }
 }

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/channel/DefaultChannelRaceConditionTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/channel/DefaultChannelRaceConditionTest.java
@@ -11,6 +11,7 @@ import com.microsoft.azure.mobile.ingestion.models.Log;
 import com.microsoft.azure.mobile.ingestion.models.LogContainer;
 import com.microsoft.azure.mobile.persistence.DatabasePersistenceAsync;
 import com.microsoft.azure.mobile.persistence.Persistence;
+import com.microsoft.azure.mobile.utils.HandlerUtils;
 import com.microsoft.azure.mobile.utils.UUIDUtils;
 
 import org.junit.Test;
@@ -337,6 +338,54 @@ public class DefaultChannelRaceConditionTest extends AbstractDefaultChannelTest 
         channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, listener);
         channel.removeGroup(TEST_GROUP);
         channel.addGroup(TEST_GROUP, 2, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, listener);
+
+        /* Release call to mock ingestion. */
+        beforeCallSemaphore.release();
+
+        /* Wait for callback ingestion. */
+        afterCallSemaphore.acquireUninterruptibly();
+
+        /* Verify ingestion not sent. */
+        verify(mockIngestion, never()).sendAsync(anyString(), any(UUID.class), any(LogContainer.class), any(ServiceCallback.class));
+    }
+
+    @Test
+    public void disabledWhileSendingLogs() throws Exception {
+
+        /* Set up mocking. */
+        final Semaphore beforeCallSemaphore = new Semaphore(0);
+        final Semaphore afterCallSemaphore = new Semaphore(0);
+        Persistence mockPersistence = mock(Persistence.class);
+        when(mockPersistence.countLogs(anyString())).thenReturn(1);
+        when(mockPersistence.getLogs(anyString(), eq(1), anyListOf(Log.class))).then(getGetLogsAnswer(1));
+        when(mockPersistence.getLogs(anyString(), eq(CLEAR_BATCH_SIZE), anyListOf(Log.class))).then(getGetLogsAnswer(0));
+        DatabasePersistenceAsync mockPersistenceAsync = spy(new DatabasePersistenceAsync(mockPersistence));
+        whenNew(DatabasePersistenceAsync.class).withArguments(mockPersistence).thenReturn(mockPersistenceAsync);
+        IngestionHttp mockIngestion = mock(IngestionHttp.class);
+        doAnswer(new Answer<Void>() {
+
+            @Override
+            public Void answer(final InvocationOnMock invocation) throws Throwable {
+                new Thread() {
+
+                    @Override
+                    public void run() {
+                        beforeCallSemaphore.acquireUninterruptibly();
+                        ((Runnable) invocation.getArguments()[0]).run();
+                        afterCallSemaphore.release();
+                    }
+                }.start();
+                return null;
+            }
+        }).when(HandlerUtils.class);
+        HandlerUtils.runOnUiThread(any(Runnable.class));
+
+        /* Simulate enable module then disable. */
+        DefaultChannel channel = new DefaultChannel(mock(Context.class), UUIDUtils.randomUUID().toString(), mockPersistence, mockIngestion);
+        Channel.GroupListener listener = mock(Channel.GroupListener.class);
+        channel.addGroup(TEST_GROUP, 1, BATCH_TIME_INTERVAL, MAX_PARALLEL_BATCHES, listener);
+        channel.setEnabled(false);
+        channel.setEnabled(true);
 
         /* Release call to mock ingestion. */
         beforeCallSemaphore.release();


### PR DESCRIPTION
Without this PR we can randomly get this crash on API level 15:

```
FATAL EXCEPTION: main
                                                 java.lang.RuntimeException: Unable to pause activity {com.microsoft.azure.mobile.sasquatch.jcenter/com.microsoft.azure.mobile.sasquatch.activities.MainActivity}: android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
                                                     at android.app.ActivityThread.performPauseActivity(ActivityThread.java:2706)
                                                     at android.app.ActivityThread.performPauseActivity(ActivityThread.java:2662)
                                                     at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:2640)
                                                     at android.app.ActivityThread.access$800(ActivityThread.java:123)
                                                     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1154)
                                                     at android.os.Handler.dispatchMessage(Handler.java:99)
                                                     at android.os.Looper.loop(Looper.java:137)
                                                     at android.app.ActivityThread.main(ActivityThread.java:4424)
                                                     at java.lang.reflect.Method.invokeNative(Native Method)
                                                     at java.lang.reflect.Method.invoke(Method.java:511)
                                                     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:784)
                                                     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:551)
                                                     at dalvik.system.NativeStart.main(Native Method)
                                                  Caused by: android.view.ViewRootImpl$CalledFromWrongThreadException: Only the original thread that created a view hierarchy can touch its views.
                                                     at android.view.ViewRootImpl.checkThread(ViewRootImpl.java:4039)
                                                     at android.view.ViewRootImpl.requestLayout(ViewRootImpl.java:709)
                                                     at android.view.View.requestLayout(View.java:12675)
                                                     at android.view.View.setFlags(View.java:6720)
                                                     at android.view.View.setVisibility(View.java:4617)
                                                     at android.app.Dialog.hide(Dialog.java:291)
                                                     at com.microsoft.azure.mobile.distribute.Distribute$9.run(Distribute.java:1147)
                                                     at com.microsoft.azure.mobile.utils.HandlerUtils.runOnUiThread(HandlerUtils.java:25)
                                                     at com.microsoft.azure.mobile.distribute.Distribute.hideProgressDialog(Distribute.java:1143)
                                                     at com.microsoft.azure.mobile.distribute.Distribute.onActivityPaused(Distribute.java:322)
                                                     at android.app.Application.dispatchActivityPaused(Application.java:182)
                                                     at android.app.Activity.onPause(Activity.java:1245)
                                                     at android.support.v4.app.FragmentActivity.onPause(FragmentActivity.java:442)
                                                     at android.app.Activity.performPause(Activity.java:4563)
                                                     at android.app.Instrumentation.callActivityOnPause(Instrumentation.java:1195)
                                                     at android.app.ActivityThread.performPauseActivity(ActivityThread.java:2693)
                                                     at android.app.ActivityThread.performPauseActivity(ActivityThread.java:2662) 
                                                     at android.app.ActivityThread.handlePauseActivity(ActivityThread.java:2640) 
                                                     at android.app.ActivityThread.access$800(ActivityThread.java:123) 
                                                     at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1154) 
                                                     at android.os.Handler.dispatchMessage(Handler.java:99) 
                                                     at android.os.Looper.loop(Looper.java:137) 
                                                     at android.app.ActivityThread.main(ActivityThread.java:4424) 
                                                     at java.lang.reflect.Method.invokeNative(Native Method) 
                                                     at java.lang.reflect.Method.invoke(Method.java:511) 
                                                     at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:784) 
                                                     at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:551) 
                                                     at dalvik.system.NativeStart.main(Native Method) 
```