### PR TITLE
Fix 2 scenarios where progress dialog can be stuck at 100%

### DIFF
--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/AbstractDistributeAfterDownloadTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/AbstractDistributeAfterDownloadTest.java
@@ -43,6 +43,7 @@ import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFEREN
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_RELEASE_DETAILS;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_TOKEN;
+import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.anyLong;
@@ -321,5 +322,14 @@ public class AbstractDistributeAfterDownloadTest extends AbstractDistributeTest 
     @After
     public void tearDown() throws Exception {
         TestUtils.setInternalState(Build.VERSION.class, "SDK_INT", 0);
+        checkSemaphoreSanity(mCheckDownloadBeforeSemaphore);
+        checkSemaphoreSanity(mCheckDownloadAfterSemaphore);
+        checkSemaphoreSanity(mDownloadBeforeSemaphore);
+        checkSemaphoreSanity(mDownloadAfterSemaphore);
+    }
+
+    void checkSemaphoreSanity(Semaphore semaphore) {
+        assertEquals(0, semaphore.availablePermits());
+        assertEquals(0, semaphore.getQueueLength());
     }
 }

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/AbstractDistributeTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/AbstractDistributeTest.java
@@ -119,6 +119,7 @@ public class AbstractDistributeTest {
         when(PreferencesStorage.getLong(PREFERENCE_KEY_DOWNLOAD_ID, INVALID_DOWNLOAD_IDENTIFIER)).thenReturn(INVALID_DOWNLOAD_IDENTIFIER);
 
         /* Mock package manager. */
+        when(mContext.getApplicationContext()).thenReturn(mContext);
         when(mContext.getPackageName()).thenReturn("com.contoso");
         when(mActivity.getPackageName()).thenReturn("com.contoso");
         when(mContext.getApplicationInfo()).thenReturn(mApplicationInfo);

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DistributeHttpTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DistributeHttpTest.java
@@ -14,6 +14,7 @@ import com.microsoft.azure.mobile.utils.UUIDUtils;
 
 import junit.framework.Assert;
 
+import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -44,6 +45,11 @@ public class DistributeHttpTest {
 
     @Rule
     public PowerMockRule rule = new PowerMockRule();
+
+    @Before
+    public void setUp() {
+        Distribute.unsetInstance();
+    }
 
     @Test
     public void onBeforeCalling() throws Exception {


### PR DESCRIPTION
* If receiving completion callback and updating progress at the same time.
* If application exits while processing completion callback.