### PR TITLE
enableFirebaseAnalytics method added to Push module 

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/MainActivity.java
@@ -34,6 +34,7 @@ public class MainActivity extends AppCompatActivity {
 
     static final String APP_SECRET_KEY = "appSecret";
     static final String LOG_URL_KEY = "logUrl";
+    static final String FIREBASE_ENABLED_KEY = "firebaseEnabled";
     private static final String LOG_TAG = "MobileCenterSasquatch";
     static SharedPreferences sSharedPreferences;
 
@@ -44,6 +45,9 @@ public class MainActivity extends AppCompatActivity {
 
         sSharedPreferences = getSharedPreferences("Sasquatch", Context.MODE_PRIVATE);
         StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectDiskReads().detectDiskWrites().build());
+
+        /* Remove firebase analytics enabled setting. */
+        sSharedPreferences.edit().remove(FIREBASE_ENABLED_KEY).apply();
 
         /* Set custom log URL if one was configured in settings. */
         String logUrl = sSharedPreferences.getString(LOG_URL_KEY, getString(R.string.log_url));

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivity.java
@@ -359,7 +359,7 @@ public class SettingsActivity extends AppCompatActivity {
             editor.apply();
         }
 
-        private boolean isFirebaseEnabled(){
+        private boolean isFirebaseEnabled() {
             return MainActivity.sSharedPreferences.getString(FIREBASE_ENABLED_KEY, null) != null;
         }
 

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivity.java
@@ -31,10 +31,9 @@ import java.util.UUID;
 
 import static com.microsoft.azure.mobile.sasquatch.activities.MainActivity.APP_SECRET_KEY;
 import static com.microsoft.azure.mobile.sasquatch.activities.MainActivity.LOG_URL_KEY;
+import static com.microsoft.azure.mobile.sasquatch.activities.MainActivity.FIREBASE_ENABLED_KEY;
 
 public class SettingsActivity extends AppCompatActivity {
-
-    private static final String FIREBASE_ENABLED_KEY = "firebaseEnabled";
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivity.java
@@ -34,6 +34,8 @@ import static com.microsoft.azure.mobile.sasquatch.activities.MainActivity.LOG_U
 
 public class SettingsActivity extends AppCompatActivity {
 
+    private static final String FIREBASE_ENABLED_KEY = "firebaseEnabled";
+
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -55,6 +57,7 @@ public class SettingsActivity extends AppCompatActivity {
             final CheckBoxPreference distributeEnabledPreference = (CheckBoxPreference) getPreferenceManager().findPreference(getString(R.string.mobile_center_distribute_state_key));
             final CheckBoxPreference pushEnabledPreference = (CheckBoxPreference) getPreferenceManager().findPreference(getString(R.string.mobile_center_push_state_key));
             final CheckBoxPreference firebaseEnabledPreference = (CheckBoxPreference) getPreferenceManager().findPreference(getString(R.string.mobile_center_push_firebase_state_key));
+            firebaseEnabledPreference.setEnabled(!isFirebaseEnabled());
             initCheckBoxSetting(R.string.mobile_center_state_key, MobileCenter.isEnabled(), R.string.mobile_center_state_summary_enabled, R.string.mobile_center_state_summary_disabled, new HasEnabled() {
 
                 @Override
@@ -141,13 +144,15 @@ public class SettingsActivity extends AppCompatActivity {
                 });
 
                 final Method enableFirebaseAnalytics = push.getMethod("enableFirebaseAnalytics", Context.class);
-                initCheckBoxSetting(R.string.mobile_center_push_firebase_state_key, false, R.string.mobile_center_push_firebase_summary_enabled, R.string.mobile_center_push_firebase_summary_disabled, new HasEnabled() {
+                initCheckBoxSetting(R.string.mobile_center_push_firebase_state_key, isFirebaseEnabled(), R.string.mobile_center_push_firebase_summary_enabled, R.string.mobile_center_push_firebase_summary_disabled, new HasEnabled() {
 
                     @Override
                     public void setEnabled(boolean enabled) {
                         try {
                             enableFirebaseAnalytics.invoke(null, getActivity());
+                            setKeyValue(FIREBASE_ENABLED_KEY, "enabled");
                             firebaseEnabledPreference.setChecked(true);
+                            firebaseEnabledPreference.setEnabled(false);
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
@@ -156,7 +161,7 @@ public class SettingsActivity extends AppCompatActivity {
                     @Override
                     public boolean isEnabled() {
                         try {
-                            return false;
+                            return isFirebaseEnabled();
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }
@@ -352,6 +357,10 @@ public class SettingsActivity extends AppCompatActivity {
             else
                 editor.putString(key, value);
             editor.apply();
+        }
+
+        private boolean isFirebaseEnabled(){
+            return MainActivity.sSharedPreferences.getString(FIREBASE_ENABLED_KEY, null) != null;
         }
 
         private interface HasEnabled {

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivity.java
@@ -1,6 +1,7 @@
 package com.microsoft.azure.mobile.sasquatch.activities;
 
 import android.app.AlertDialog;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.os.Bundle;
@@ -53,6 +54,7 @@ public class SettingsActivity extends AppCompatActivity {
             final CheckBoxPreference crashesEnabledPreference = (CheckBoxPreference) getPreferenceManager().findPreference(getString(R.string.mobile_center_crashes_state_key));
             final CheckBoxPreference distributeEnabledPreference = (CheckBoxPreference) getPreferenceManager().findPreference(getString(R.string.mobile_center_distribute_state_key));
             final CheckBoxPreference pushEnabledPreference = (CheckBoxPreference) getPreferenceManager().findPreference(getString(R.string.mobile_center_push_state_key));
+            final CheckBoxPreference firebaseEnabledPreference = (CheckBoxPreference) getPreferenceManager().findPreference(getString(R.string.mobile_center_push_firebase_state_key));
             initCheckBoxSetting(R.string.mobile_center_state_key, MobileCenter.isEnabled(), R.string.mobile_center_state_summary_enabled, R.string.mobile_center_state_summary_disabled, new HasEnabled() {
 
                 @Override
@@ -132,6 +134,29 @@ public class SettingsActivity extends AppCompatActivity {
                     public boolean isEnabled() {
                         try {
                             return (boolean) isEnabled.invoke(null);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+                });
+
+                final Method enableFirebaseAnalytics = push.getMethod("enableFirebaseAnalytics", Context.class);
+                initCheckBoxSetting(R.string.mobile_center_push_firebase_state_key, false, R.string.mobile_center_push_firebase_summary_enabled, R.string.mobile_center_push_firebase_summary_disabled, new HasEnabled() {
+
+                    @Override
+                    public void setEnabled(boolean enabled) {
+                        try {
+                            enableFirebaseAnalytics.invoke(null, getActivity());
+                            firebaseEnabledPreference.setChecked(true);
+                        } catch (Exception e) {
+                            throw new RuntimeException(e);
+                        }
+                    }
+
+                    @Override
+                    public boolean isEnabled() {
+                        try {
+                            return false;
                         } catch (Exception e) {
                             throw new RuntimeException(e);
                         }

--- a/apps/sasquatch/src/main/res/values/settings.xml
+++ b/apps/sasquatch/src/main/res/values/settings.xml
@@ -38,6 +38,10 @@
     <string name="push_key">mobile_center_push</string>
     <string name="push_title">Push</string>
 
+    <string name="mobile_center_push_firebase_state_key">mobile_center_push_firebase_state_key</string>
+    <string name="mobile_center_push_firebase_state_title">Firebase analytics state</string>
+    <string name="mobile_center_push_firebase_summary_enabled">Firebase analytics is enabled</string>
+    <string name="mobile_center_push_firebase_summary_disabled">Firebase analytics is disabled</string>
     <string name="mobile_center_push_state_key">mobile_center_push_state_key</string>
     <string name="mobile_center_push_state_title">Push state</string>
     <string name="mobile_center_push_state_summary_enabled">Push is enabled</string>

--- a/apps/sasquatch/src/main/res/xml/settings.xml
+++ b/apps/sasquatch/src/main/res/xml/settings.xml
@@ -37,6 +37,9 @@
         <CheckBoxPreference
             android:key="@string/mobile_center_push_state_key"
             android:title="@string/mobile_center_push_state_title"/>
+        <CheckBoxPreference
+            android:key="@string/mobile_center_push_firebase_state_key"
+            android:title="@string/mobile_center_push_firebase_state_title"/>
     </PreferenceCategory>
 
     <PreferenceCategory

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -45,7 +45,7 @@ subprojects {
         testOptions {
             unitTests {
                 all {
-                    jvmArgs = ["-noverify", "-javaagent:${configurations.testCompile.find {it.name.startsWith('powermock-module-javaagent')}}"]
+                    jvmArgs '-noverify'
                 }
                 returnDefaultValues = true
             }
@@ -63,7 +63,6 @@ subprojects {
         testCompile 'org.powermock:powermock-api-mockito:1.6.5'
         testCompile 'org.powermock:powermock-module-junit4:1.6.5'
         testCompile 'org.powermock:powermock-module-junit4-rule-agent:1.6.5'
-        testCompile 'org.powermock:powermock-module-javaagent:1.6.5'
         testCompile project(':test')
 
         androidTestCompile 'com.crittercism.dexmaker:dexmaker-dx:1.4'

--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -45,7 +45,7 @@ subprojects {
         testOptions {
             unitTests {
                 all {
-                    jvmArgs '-noverify'
+                    jvmArgs = ["-noverify", "-javaagent:${configurations.testCompile.find {it.name.startsWith('powermock-module-javaagent')}}"]
                 }
                 returnDefaultValues = true
             }
@@ -63,6 +63,7 @@ subprojects {
         testCompile 'org.powermock:powermock-api-mockito:1.6.5'
         testCompile 'org.powermock:powermock-module-junit4:1.6.5'
         testCompile 'org.powermock:powermock-module-junit4-rule-agent:1.6.5'
+        testCompile 'org.powermock:powermock-module-javaagent:1.6.5'
         testCompile project(':test')
 
         androidTestCompile 'com.crittercism.dexmaker:dexmaker-dx:1.4'

--- a/sdk/mobile-center-push/build.gradle
+++ b/sdk/mobile-center-push/build.gradle
@@ -1,8 +1,20 @@
 project.description = 'This package contains functionalities to recive push notifications for your application.'
 evaluationDependsOn(':sdk')
 
+android {
+    testOptions {
+        unitTests {
+            all {
+                jvmArgs = ["-noverify", "-javaagent:${configurations.testCompile.find {it.name.startsWith('powermock-module-javaagent')}}"]
+            }
+            returnDefaultValues = true
+        }
+    }
+}
+
 dependencies {
     compile project(':sdk:mobile-center')
+    testCompile 'org.powermock:powermock-module-javaagent:1.6.5'
 
     /* Need add explicit core dependency to avoid error on transform classes with dex task */
     compile 'com.google.firebase:firebase-core:10.2.0'

--- a/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/FirebaseAnalyticsUtils.java
+++ b/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/FirebaseAnalyticsUtils.java
@@ -7,8 +7,7 @@ import com.google.firebase.analytics.FirebaseAnalytics;
 class FirebaseAnalyticsUtils {
 
     @SuppressWarnings("MissingPermission")
-    static void setEnabled(Context context, boolean enabled)
-    {
+    static void setEnabled(Context context, boolean enabled) {
         FirebaseAnalytics.getInstance(context).setAnalyticsCollectionEnabled(enabled);
     }
 }

--- a/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/Push.java
+++ b/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/Push.java
@@ -5,7 +5,6 @@ import android.content.Context;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.microsoft.azure.mobile.AbstractMobileCenterService;
 import com.microsoft.azure.mobile.channel.Channel;

--- a/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/Push.java
+++ b/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/Push.java
@@ -122,6 +122,7 @@ public class Push extends AbstractMobileCenterService {
      *
      * @param context the context to retrieve FirebaseAnalytics instance.
      */
+    @SuppressWarnings("WeakerAccess")
     public static void enableFirebaseAnalytics(@NonNull Context context) {
         MobileCenterLog.debug(LOG_TAG, "Enabling firebase analytics collection.");
         setFirebaseAnalyticsEnabled(context, true);

--- a/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/Push.java
+++ b/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/Push.java
@@ -49,10 +49,9 @@ public class Push extends AbstractMobileCenterService {
     static final String PREFERENCE_KEY_PUSH_TOKEN = PREFERENCE_PREFIX + "push_token";
 
     /**
-     * Preference key to store if firebase analytics collections is enabled.
+     * Firebase analytics flag.
      */
-    @VisibleForTesting
-    static final String PREFERENCE_KEY_ANALYTICS_ENABLED = PREFERENCE_PREFIX + "analytics_enabled";
+    private static boolean sFirebaseAnalyticsEnabled;
 
     /**
      * Shared instance.
@@ -136,7 +135,7 @@ public class Push extends AbstractMobileCenterService {
     @SuppressWarnings("MissingPermission")
     private static void setFirebaseAnalyticsEnabled(@NonNull Context context, boolean enabled) {
         FirebaseAnalyticsUtils.setEnabled(context, enabled);
-        PreferencesStorage.putBoolean(PREFERENCE_KEY_ANALYTICS_ENABLED, enabled);
+        sFirebaseAnalyticsEnabled = enabled;
     }
 
     /**
@@ -153,7 +152,7 @@ public class Push extends AbstractMobileCenterService {
     /**
      * Handle push token update success.
      *
-     * @param pushToken the push token value
+     * @param pushToken the push token value.
      */
     @VisibleForTesting
     synchronized void onTokenRefresh(@NonNull String pushToken) {
@@ -214,7 +213,7 @@ public class Push extends AbstractMobileCenterService {
     public synchronized void onStarted(@NonNull Context context, @NonNull String appSecret, @NonNull Channel channel) {
         super.onStarted(context, appSecret, channel);
         applyEnabledState(isInstanceEnabled());
-        if (!PreferencesStorage.getBoolean(PREFERENCE_KEY_ANALYTICS_ENABLED)) {
+        if (!sFirebaseAnalyticsEnabled) {
             MobileCenterLog.debug(LOG_TAG, "Disabling firebase analytics collection by default.");
             setFirebaseAnalyticsEnabled(context, false);
         }

--- a/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/Push.java
+++ b/sdk/mobile-center-push/src/main/java/com/microsoft/azure/mobile/push/Push.java
@@ -52,6 +52,7 @@ public class Push extends AbstractMobileCenterService {
     /**
      * Preference key to store if firebase analytics collections is enabled.
      */
+    @VisibleForTesting
     static final String PREFERENCE_KEY_ANALYTICS_ENABLED = PREFERENCE_PREFIX + "analytics_enabled";
 
     /**

--- a/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
+++ b/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
@@ -92,7 +92,6 @@ public class PushTest {
         /* Mock Firebase instance. */
         mockStatic(FirebaseInstanceId.class);
         when(FirebaseInstanceId.getInstance()).thenReturn(mFirebaseInstanceId);
-
         mockStatic(FirebaseAnalyticsUtils.class);
     }
 

--- a/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
+++ b/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
@@ -27,6 +27,7 @@ import org.powermock.modules.junit4.rule.PowerMockRule;
 
 import java.util.Map;
 
+import static com.microsoft.azure.mobile.push.Push.PREFERENCE_KEY_ANALYTICS_ENABLED;
 import static com.microsoft.azure.mobile.push.Push.PREFERENCE_KEY_PUSH_TOKEN;
 import static com.microsoft.azure.mobile.utils.PrefStorageConstants.KEY_ENABLED;
 import static org.junit.Assert.assertFalse;
@@ -170,5 +171,20 @@ public class PushTest {
         Push.setEnabled(true);
         Push.setEnabled(true);
         verify(channel).enqueue(any(PushInstallationLog.class), eq(push.getGroupName()));
+    }
+
+    @Test
+    public void verifyEnableFirebaseAnalytics(){
+        Context contextMock = mock(Context.class);
+        Push push = Push.getInstance();
+        Channel channel = mock(Channel.class);
+        push.onStarted(contextMock, DUMMY_APP_SECRET, channel);
+        verify(mFirebaseAnalytics).setAnalyticsCollectionEnabled(eq(false));
+
+        /* For check enable firebase analytics collection */
+        Push.enableFirebaseAnalytics(contextMock);
+        verify(mFirebaseAnalytics).setAnalyticsCollectionEnabled(eq(true));
+        verifyStatic(times(1));
+        StorageHelper.PreferencesStorage.putBoolean(eq(PREFERENCE_KEY_ANALYTICS_ENABLED), eq(true));
     }
 }

--- a/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
+++ b/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
@@ -26,7 +26,6 @@ import org.powermock.modules.junit4.rule.PowerMockRule;
 
 import java.util.Map;
 
-import static com.microsoft.azure.mobile.push.Push.PREFERENCE_KEY_ANALYTICS_ENABLED;
 import static com.microsoft.azure.mobile.push.Push.PREFERENCE_KEY_PUSH_TOKEN;
 import static com.microsoft.azure.mobile.utils.PrefStorageConstants.KEY_ENABLED;
 import static org.junit.Assert.assertFalse;
@@ -176,20 +175,18 @@ public class PushTest {
         verifyStatic();
         FirebaseAnalyticsUtils.setEnabled(any(Context.class), eq(false));
 
-        /* For check enable firebase analytics collection */
+        /* For check enable firebase analytics collection. */
         Push.enableFirebaseAnalytics(contextMock);
         verifyStatic();
         FirebaseAnalyticsUtils.setEnabled(any(Context.class), eq(true));
-        verifyStatic(times(1));
-        StorageHelper.PreferencesStorage.putBoolean(eq(PREFERENCE_KEY_ANALYTICS_ENABLED), eq(true));
     }
 
     @Test
-    public void verifyFirebaseAnalyticsStaysEnabled() {
+    public void verifyEnableFirebaseAnalyticsBeforeStart() {
         Context contextMock = mock(Context.class);
         Push push = Push.getInstance();
         Channel channel = mock(Channel.class);
-        when(StorageHelper.PreferencesStorage.getBoolean(PREFERENCE_KEY_ANALYTICS_ENABLED)).thenReturn(true);
+        Push.enableFirebaseAnalytics(contextMock);
         push.onStarted(contextMock, DUMMY_APP_SECRET, channel);
         verifyStatic(never());
         FirebaseAnalyticsUtils.setEnabled(any(Context.class), eq(false));

--- a/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
+++ b/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
@@ -2,6 +2,7 @@ package com.microsoft.azure.mobile.push;
 
 import android.content.Context;
 
+import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.microsoft.azure.mobile.MobileCenter;
 import com.microsoft.azure.mobile.channel.Channel;
@@ -43,14 +44,15 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 import static org.powermock.api.mockito.PowerMockito.verifyStatic;
 import static org.powermock.api.mockito.PowerMockito.when;
 
-@SuppressWarnings("unused")
+@SuppressWarnings({"unused", "MissingPermission"})
 @PrepareForTest({
         Push.class,
         PushInstallationLog.class,
         MobileCenterLog.class,
         MobileCenter.class,
         StorageHelper.PreferencesStorage.class,
-        FirebaseInstanceId.class
+        FirebaseInstanceId.class,
+        FirebaseAnalytics.class
 })
 public class PushTest {
 
@@ -62,6 +64,9 @@ public class PushTest {
 
     @Mock
     FirebaseInstanceId mFirebaseInstanceId;
+
+    @Mock
+    FirebaseAnalytics mFirebaseAnalytics;
 
     @Before
     public void setUp() throws Exception {
@@ -90,6 +95,9 @@ public class PushTest {
         /* Mock Firebase instance. */
         mockStatic(FirebaseInstanceId.class);
         when(FirebaseInstanceId.getInstance()).thenReturn(mFirebaseInstanceId);
+
+        mockStatic(FirebaseAnalytics.class);
+        when(FirebaseAnalytics.getInstance(any(Context.class))).thenReturn(mFirebaseAnalytics);
     }
 
     @Test

--- a/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
+++ b/sdk/mobile-center-push/src/test/java/com/microsoft/azure/mobile/push/PushTest.java
@@ -2,7 +2,6 @@ package com.microsoft.azure.mobile.push;
 
 import android.content.Context;
 
-import com.google.firebase.analytics.FirebaseAnalytics;
 import com.google.firebase.iid.FirebaseInstanceId;
 import com.microsoft.azure.mobile.MobileCenter;
 import com.microsoft.azure.mobile.channel.Channel;
@@ -170,7 +169,7 @@ public class PushTest {
     }
 
     @Test
-    public void verifyEnableFirebaseAnalytics(){
+    public void verifyEnableFirebaseAnalytics() {
         Context contextMock = mock(Context.class);
         Push push = Push.getInstance();
         Channel channel = mock(Channel.class);
@@ -184,5 +183,16 @@ public class PushTest {
         FirebaseAnalyticsUtils.setEnabled(any(Context.class), eq(true));
         verifyStatic(times(1));
         StorageHelper.PreferencesStorage.putBoolean(eq(PREFERENCE_KEY_ANALYTICS_ENABLED), eq(true));
+    }
+
+    @Test
+    public void verifyFirebaseAnalyticsStaysEnabled() {
+        Context contextMock = mock(Context.class);
+        Push push = Push.getInstance();
+        Channel channel = mock(Channel.class);
+        when(StorageHelper.PreferencesStorage.getBoolean(PREFERENCE_KEY_ANALYTICS_ENABLED)).thenReturn(true);
+        push.onStarted(contextMock, DUMMY_APP_SECRET, channel);
+        verifyStatic(never());
+        FirebaseAnalyticsUtils.setEnabled(any(Context.class), eq(false));
     }
 }


### PR DESCRIPTION
Firebase Analytics is disabled by default, and only after user calls enableFirebaseAnalytics it is enabled