### PR TITLE
Add crashes UI tests

### DIFF
--- a/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/AnalyticsTest.java
+++ b/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/AnalyticsTest.java
@@ -1,21 +1,12 @@
 package com.microsoft.azure.mobile.sasquatch.activities;
 
 
-import android.support.annotation.StringRes;
 import android.support.test.espresso.Espresso;
-import android.support.test.espresso.NoMatchingViewException;
-import android.support.test.espresso.UiController;
-import android.support.test.espresso.ViewAction;
-import android.support.test.espresso.ViewAssertion;
-import android.support.test.espresso.ViewInteraction;
 import android.support.test.rule.ActivityTestRule;
-import android.view.View;
 
 import com.microsoft.azure.mobile.Constants;
 import com.microsoft.azure.mobile.sasquatch.R;
 
-import org.hamcrest.Matcher;
-import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 
@@ -24,23 +15,21 @@ import static android.support.test.espresso.action.ViewActions.click;
 import static android.support.test.espresso.action.ViewActions.closeSoftKeyboard;
 import static android.support.test.espresso.action.ViewActions.replaceText;
 import static android.support.test.espresso.assertion.ViewAssertions.matches;
-import static android.support.test.espresso.matcher.RootMatchers.withDecorView;
 import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
 import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
 import static android.support.test.espresso.matcher.ViewMatchers.withChild;
 import static android.support.test.espresso.matcher.ViewMatchers.withId;
 import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.CHECK_DELAY;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.TOAST_DELAY;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.onToast;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.waitFor;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.withContainsText;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.anyOf;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.not;
 
 @SuppressWarnings("unused")
 public class AnalyticsTest {
-
-    private static final int CHECK_DELAY = 50;
-    private static final int TOAST_DELAY = 2000;
 
     @Rule
     public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class);
@@ -57,10 +46,13 @@ public class AnalyticsTest {
         onView(withText(R.string.send)).perform(click());
 
         /* Check toasts. */
-        waitFor(onToast(withText(R.string.event_before_sending)), Constants.DEFAULT_TRIGGER_INTERVAL + CHECK_DELAY)
+        waitFor(onToast(mActivityTestRule.getActivity(),
+                withText(R.string.event_before_sending)), Constants.DEFAULT_TRIGGER_INTERVAL + CHECK_DELAY)
                 .check(matches(isDisplayed()));
         waitAnalytics();
-        waitFor(onToast(anyOf(withContainsText(R.string.event_sent_succeeded), withContainsText(R.string.event_sent_failed))), TOAST_DELAY)
+        waitFor(onToast(mActivityTestRule.getActivity(), anyOf(
+                withContainsText(R.string.event_sent_succeeded),
+                withContainsText(R.string.event_sent_failed))), TOAST_DELAY)
                 .check(matches(isDisplayed()));
     }
 
@@ -76,65 +68,18 @@ public class AnalyticsTest {
         onView(withText(R.string.send)).perform(click());
 
         /* Check toasts. */
-        waitFor(onToast(withText(R.string.page_before_sending)), Constants.DEFAULT_TRIGGER_INTERVAL + CHECK_DELAY)
+        waitFor(onToast(mActivityTestRule.getActivity(), withText(R.string.page_before_sending)), Constants.DEFAULT_TRIGGER_INTERVAL + CHECK_DELAY)
                 .check(matches(isDisplayed()));
         waitAnalytics();
-        waitFor(onToast(anyOf(withContainsText(R.string.page_sent_succeeded), withContainsText(R.string.page_sent_failed))), TOAST_DELAY)
+        waitFor(onToast(mActivityTestRule.getActivity(), anyOf(
+                withContainsText(R.string.page_sent_succeeded),
+                withContainsText(R.string.page_sent_failed))), TOAST_DELAY)
                 .check(matches(isDisplayed()));
-    }
-
-    private ViewInteraction onToast(final Matcher<View> viewMatcher) {
-        return onView(viewMatcher).inRoot(withDecorView(not(is(mActivityTestRule.getActivity().getWindow().getDecorView()))));
-    }
-
-    private Matcher<View> withContainsText(@StringRes final int resourceId) {
-        return withText(containsString(mActivityTestRule.getActivity().getString(resourceId)));
     }
 
     private void waitAnalytics() {
         Espresso.registerIdlingResources(MainActivity.analyticsIdlingResource);
         onView(isRoot()).perform(waitFor(CHECK_DELAY));
         Espresso.unregisterIdlingResources(MainActivity.analyticsIdlingResource);
-    }
-
-    private static ViewAction waitFor(final long millis) {
-        return new ViewAction() {
-
-            @Override
-            public Matcher<View> getConstraints() {
-                return isRoot();
-            }
-
-            @Override
-            public String getDescription() {
-                return "Wait for " + millis + " milliseconds.";
-            }
-
-            @Override
-            public void perform(UiController uiController, final View view) {
-                uiController.loopMainThreadForAtLeast(millis);
-            }
-        };
-    }
-
-    private static ViewInteraction waitFor(final ViewInteraction viewInteraction, final long millis) throws InterruptedException {
-        final long startTime = System.currentTimeMillis();
-        final long endTime = startTime + millis;
-        final View[] found = new View[] { null };
-        while (System.currentTimeMillis() < endTime)
-        {
-            viewInteraction.check(new ViewAssertion() {
-
-                @Override
-                public void check(View view, NoMatchingViewException noViewFoundException) {
-                    found[0] = view;
-                }
-            });
-            if (found[0] != null)
-                return viewInteraction;
-            Thread.sleep(CHECK_DELAY);
-        }
-        Assert.fail();
-        return viewInteraction;
     }
 }

--- a/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/CrashesTest.java
+++ b/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/CrashesTest.java
@@ -1,0 +1,232 @@
+package com.microsoft.azure.mobile.sasquatch.activities;
+
+import android.content.Context;
+import android.content.Intent;
+import android.support.annotation.StringRes;
+import android.support.test.espresso.Espresso;
+import android.support.test.espresso.EspressoException;
+import android.support.test.espresso.FailureHandler;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.matcher.BoundedMatcher;
+import android.support.test.rule.ActivityTestRule;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.IntentCompat;
+import android.view.View;
+
+import com.microsoft.azure.mobile.Constants;
+import com.microsoft.azure.mobile.MobileCenter;
+import com.microsoft.azure.mobile.crashes.Crashes;
+import com.microsoft.azure.mobile.crashes.CrashesPrivateHelper;
+import com.microsoft.azure.mobile.crashes.utils.ErrorLogHelper;
+import com.microsoft.azure.mobile.sasquatch.R;
+import com.microsoft.azure.mobile.utils.storage.StorageHelper;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.io.File;
+import java.lang.reflect.Method;
+
+import static android.support.test.InstrumentationRegistry.getInstrumentation;
+import static android.support.test.espresso.Espresso.onData;
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.assertion.ViewAssertions.matches;
+import static android.support.test.espresso.matcher.RootMatchers.isDialog;
+import static android.support.test.espresso.matcher.ViewMatchers.isDisplayed;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static android.support.test.espresso.matcher.ViewMatchers.withChild;
+import static android.support.test.espresso.matcher.ViewMatchers.withText;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.CHECK_DELAY;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.TOAST_DELAY;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.onToast;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.waitFor;
+import static com.microsoft.azure.mobile.sasquatch.activities.utils.EspressoUtils.withContainsText;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.junit.Assert.assertTrue;
+
+@SuppressWarnings("unused")
+public class CrashesTest {
+
+    @Rule
+    public ActivityTestRule<MainActivity> mActivityTestRule = new ActivityTestRule<>(MainActivity.class, true, false);
+
+    private Context mContext;
+
+    @Before
+    public void setUp() throws Exception {
+        mContext = getInstrumentation().getTargetContext();
+
+        /* Clear preferences. */
+        StorageHelper.initialize(mContext);
+        StorageHelper.PreferencesStorage.clear();
+
+        /* Clear crashes. */
+        Constants.loadFromContext(mContext);
+        for (File logFile : ErrorLogHelper.getErrorStorageDirectory().listFiles()) {
+            assertTrue(logFile.delete());
+        }
+
+        /* Launch main activity and go to setting page. Required to properly initialize. */
+        mActivityTestRule.launchActivity(new Intent());
+
+        /* Register IdlingResource */
+        Espresso.registerIdlingResources(MainActivity.crashesIdlingResource);
+    }
+
+
+    @After
+    public final void tearDown() {
+
+        /* Unregister IdlingResource */
+        Espresso.unregisterIdlingResources(MainActivity.crashesIdlingResource);
+    }
+
+    @Test
+    public void testCrashTest() throws InterruptedException {
+        crashTest(R.string.title_test_crash);
+    }
+
+    @Test
+    public void divideByZeroTest() throws InterruptedException {
+        crashTest(R.string.title_crash_divide_by_0);
+    }
+
+    @Test
+    public void uiCrashTest() throws InterruptedException {
+        crashTest(R.string.title_test_ui_crash);
+    }
+
+//    @Test
+//    public void stackOverflowTest() throws InterruptedException {
+//        crashTest(R.string.title_stack_overflow_crash);
+//    }
+//
+//    @Test
+//    public void memoryTest() throws InterruptedException {
+//        crashTest(R.string.title_memory_crash);
+//    }
+//
+//    @Test
+//    public void memory2Test() throws InterruptedException {
+//        crashTest(R.string.title_memory_crash2);
+//    }
+
+    @Test
+    public void variableMessageTest() throws InterruptedException {
+        crashTest(R.string.title_variable_message);
+    }
+
+//    @Test
+//    public void variableMessage2Test() throws InterruptedException {
+//        crashTest(R.string.title_variable_message2);
+//    }
+//
+//    @Test
+//    public void superNotCalledTest() throws InterruptedException {
+//        crashTest(R.string.title_super_not_called_exception);
+//    }
+//
+//    @Test
+//    public void superNotCalled2Test() throws InterruptedException {
+//        crashTest(R.string.title_super_not_called_exception2);
+//    }
+//
+//    @Test
+//    public void superNotCalled3Test() throws InterruptedException {
+//        crashTest(R.string.title_super_not_called_exception3);
+//    }
+//
+//    @Test
+//    public void superNotCalled4Test() throws InterruptedException {
+//        crashTest(R.string.title_super_not_called_exception4);
+//    }
+
+    private void crashTest(@StringRes int titleId) throws InterruptedException {
+
+        /* Crash. */
+        onView(allOf(
+                withChild(withText(R.string.title_crashes)),
+                withChild(withText(R.string.description_crashes))))
+                .perform(click());
+
+        onCrash(titleId)
+                .withFailureHandler(new CrashFailureHandler())
+                .perform(click());
+
+        /* Check error report. */
+        assertTrue(Crashes.hasCrashedInLastSession());
+
+        /* Send report. */
+        waitFor(onView(withText(R.string.crash_confirmation_dialog_send_button))
+                .inRoot(isDialog()), 1000)
+                .perform(click());
+
+        /* Check toasts. */
+        waitFor(onToast(mActivityTestRule.getActivity(),
+                withText(R.string.crash_before_sending)), CHECK_DELAY)
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(CHECK_DELAY));
+        waitFor(onToast(mActivityTestRule.getActivity(), anyOf(
+                withContainsText(R.string.crash_sent_succeeded),
+                withText(R.string.crash_sent_failed))), TOAST_DELAY)
+                .check(matches(isDisplayed()));
+        onView(isRoot()).perform(waitFor(TOAST_DELAY));
+    }
+
+    private ViewInteraction onCrash(@StringRes int titleId) {
+        return onData(allOf(instanceOf(CrashActivity.Crash.class), withCrashTitle(titleId)))
+                .perform();
+    }
+
+    @SuppressWarnings("rawtypes")
+    private static Matcher<Object> withCrashTitle(@StringRes final int titleId) {
+        return new BoundedMatcher<Object, CrashActivity.Crash>(CrashActivity.Crash.class) {
+            @Override
+            public boolean matchesSafely(CrashActivity.Crash map) {
+                return map.title == titleId;
+            }
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("with item title from resource id: ");
+                description.appendValue(titleId);
+            }
+        };
+    }
+
+    private class CrashFailureHandler implements FailureHandler {
+
+        @Override
+        public void handle(Throwable error, Matcher<View> viewMatcher) {
+            Throwable uncaughtException = error instanceof EspressoException ? error.getCause() : error;
+
+            /* Save exception. */
+            CrashesPrivateHelper.saveUncaughtException(mContext.getMainLooper().getThread(), uncaughtException);
+
+            /* Relaunch. */
+            ActivityCompat.finishAffinity(mActivityTestRule.getActivity());
+            unsetInstance(MobileCenter.class);
+            unsetInstance(Crashes.class);
+            Intent intent = new Intent();
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK | IntentCompat.FLAG_ACTIVITY_CLEAR_TASK);
+            mActivityTestRule.launchActivity(intent);
+        }
+
+        @SuppressWarnings("unchecked")
+        private void unsetInstance(Class clazz) {
+            try {
+                Method m = clazz.getDeclaredMethod("unsetInstance");
+                m.setAccessible(true);
+                m.invoke(null);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+        }
+    }
+}

--- a/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/CrashesTest.java
+++ b/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/CrashesTest.java
@@ -80,7 +80,6 @@ public class CrashesTest {
         Espresso.registerIdlingResources(MainActivity.crashesIdlingResource);
     }
 
-
     @After
     public final void tearDown() {
 
@@ -103,51 +102,28 @@ public class CrashesTest {
         crashTest(R.string.title_test_ui_crash);
     }
 
-//    @Test
-//    public void stackOverflowTest() throws InterruptedException {
-//        crashTest(R.string.title_stack_overflow_crash);
-//    }
-//
-//    @Test
-//    public void memoryTest() throws InterruptedException {
-//        crashTest(R.string.title_memory_crash);
-//    }
-//
-//    @Test
-//    public void memory2Test() throws InterruptedException {
-//        crashTest(R.string.title_memory_crash2);
-//    }
-
     @Test
     public void variableMessageTest() throws InterruptedException {
         crashTest(R.string.title_variable_message);
     }
 
-//    @Test
-//    public void variableMessage2Test() throws InterruptedException {
-//        crashTest(R.string.title_variable_message2);
-//    }
-//
-//    @Test
-//    public void superNotCalledTest() throws InterruptedException {
-//        crashTest(R.string.title_super_not_called_exception);
-//    }
-//
-//    @Test
-//    public void superNotCalled2Test() throws InterruptedException {
-//        crashTest(R.string.title_super_not_called_exception2);
-//    }
-//
-//    @Test
-//    public void superNotCalled3Test() throws InterruptedException {
-//        crashTest(R.string.title_super_not_called_exception3);
-//    }
-//
-//    @Test
-//    public void superNotCalled4Test() throws InterruptedException {
-//        crashTest(R.string.title_super_not_called_exception4);
-//    }
-
+    /**
+     * Crash and sending report test.
+     * <p>
+     * We can't truly restart application in tests, so some kind of crashes can't be tested by this method.
+     * Out of memory or stack overflow - crash the test process;
+     * UI states errors - problems with restart activity;
+     * <p>
+     * Also to avoid flakiness, please setup your test environment
+     * (https://google.github.io/android-testing-support-library/docs/espresso/setup/index.html#setup-your-test-environment).
+     * On your device, under Settings->Developer options disable the following 3 settings:
+     * - Window animation scale
+     * - Transition animation scale
+     * - Animator duration scale
+     *
+     * @param titleId Title string resource to find list item.
+     * @throws InterruptedException If the current thread is interrupted.
+     */
     private void crashTest(@StringRes int titleId) throws InterruptedException {
 
         /* Crash. */
@@ -188,10 +164,12 @@ public class CrashesTest {
     @SuppressWarnings("rawtypes")
     private static Matcher<Object> withCrashTitle(@StringRes final int titleId) {
         return new BoundedMatcher<Object, CrashActivity.Crash>(CrashActivity.Crash.class) {
+
             @Override
             public boolean matchesSafely(CrashActivity.Crash map) {
                 return map.title == titleId;
             }
+
             @Override
             public void describeTo(Description description) {
                 description.appendText("with item title from resource id: ");

--- a/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivityTest.java
+++ b/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/SettingsActivityTest.java
@@ -5,11 +5,13 @@ import android.content.Intent;
 import android.support.test.espresso.DataInteraction;
 import android.support.test.rule.ActivityTestRule;
 
+import com.microsoft.azure.mobile.Constants;
 import com.microsoft.azure.mobile.MobileCenter;
 import com.microsoft.azure.mobile.analytics.Analytics;
 import com.microsoft.azure.mobile.crashes.Crashes;
 import com.microsoft.azure.mobile.distribute.Distribute;
 import com.microsoft.azure.mobile.sasquatch.R;
+import com.microsoft.azure.mobile.utils.storage.StorageHelper;
 
 import org.junit.Assert;
 import org.junit.Before;
@@ -39,7 +41,8 @@ public class SettingsActivityTest {
         mContext = getInstrumentation().getTargetContext();
 
         /* Clear preferences. */
-        mContext.getSharedPreferences("MobileCenter", Context.MODE_PRIVATE).edit().clear().apply();
+        StorageHelper.initialize(mContext);
+        StorageHelper.PreferencesStorage.clear();
 
         /* Launch main activity and go to setting page. Required to properly initialize. */
         mActivityTestRule.launchActivity(new Intent());

--- a/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/utils/EspressoUtils.java
+++ b/apps/sasquatch/src/androidTest/java/com/microsoft/azure/mobile/sasquatch/activities/utils/EspressoUtils.java
@@ -1,0 +1,97 @@
+package com.microsoft.azure.mobile.sasquatch.activities.utils;
+
+import android.app.Activity;
+import android.support.annotation.StringRes;
+import android.support.test.espresso.NoMatchingRootException;
+import android.support.test.espresso.NoMatchingViewException;
+import android.support.test.espresso.UiController;
+import android.support.test.espresso.ViewAction;
+import android.support.test.espresso.ViewAssertion;
+import android.support.test.espresso.ViewInteraction;
+import android.support.test.espresso.matcher.BoundedMatcher;
+import android.view.View;
+import android.widget.TextView;
+
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.junit.Assert;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.matcher.RootMatchers.withDecorView;
+import static android.support.test.espresso.matcher.ViewMatchers.isRoot;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
+
+public final class EspressoUtils {
+
+    public static final int CHECK_DELAY = 50;
+    public static final int TOAST_DELAY = 2000;
+
+    private EspressoUtils() {
+    }
+
+    public static ViewInteraction onToast(Activity activity, final Matcher<View> viewMatcher) {
+        return onView(viewMatcher).inRoot(withDecorView(not(is(activity.getWindow().getDecorView()))));
+    }
+
+    public static Matcher<View> withContainsText(@StringRes final int resourceId) {
+        return new BoundedMatcher<View, TextView>(TextView.class) {
+            @Override
+            public void describeTo(Description description) {
+                description.appendText("with text from resource id: ");
+                description.appendValue(resourceId);
+            }
+
+            @Override
+            public boolean matchesSafely(TextView textView) {
+                String substring = textView.getResources().getString(resourceId);
+                String text = textView.getText().toString();
+                return text.contains(substring);
+            }
+        };
+    }
+
+    public static ViewAction waitFor(final long millis) {
+        return new ViewAction() {
+
+            @Override
+            public Matcher<View> getConstraints() {
+                return isRoot();
+            }
+
+            @Override
+            public String getDescription() {
+                return "Wait for " + millis + " milliseconds.";
+            }
+
+            @Override
+            public void perform(UiController uiController, final View view) {
+                uiController.loopMainThreadForAtLeast(millis);
+            }
+        };
+    }
+
+    public static ViewInteraction waitFor(final ViewInteraction viewInteraction, final long millis) throws InterruptedException {
+        final long startTime = System.currentTimeMillis();
+        final long endTime = startTime + millis;
+        final View[] found = new View[] { null };
+        while (System.currentTimeMillis() < endTime)
+        {
+            try {
+                viewInteraction.check(new ViewAssertion() {
+
+                    @Override
+                    public void check(View view, NoMatchingViewException noViewFoundException) {
+                        found[0] = view;
+                    }
+                });
+            } catch (NoMatchingRootException ignored) {
+            }
+            if (found[0] != null)
+                return viewInteraction;
+            Thread.sleep(CHECK_DELAY);
+        }
+        Assert.fail();
+        return viewInteraction;
+    }
+}

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/crashes/CrashesPrivateHelper.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/crashes/CrashesPrivateHelper.java
@@ -8,4 +8,8 @@ public final class CrashesPrivateHelper {
     public static void trackException(Throwable throwable) {
         Crashes.trackException(throwable);
     }
+
+    public static void saveUncaughtException(Thread thread, Throwable exception) {
+        Crashes.getInstance().saveUncaughtException(thread, exception);
+    }
 }

--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/CrashActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/CrashActivity.java
@@ -4,6 +4,7 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.VisibleForTesting;
 import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.view.ViewGroup;
@@ -37,7 +38,7 @@ public class CrashActivity extends AppCompatActivity {
                     throw new TestCrashException();
                 }
             }),
-            new Crash(R.string.title_crash_divide_by_0, R.string.title_crash_divide_by_0, new Runnable() {
+            new Crash(R.string.title_crash_divide_by_0, R.string.description_crash_divide_by_0, new Runnable() {
 
                 @Override
                 @SuppressWarnings("ResultOfMethodCallIgnored")
@@ -163,7 +164,8 @@ public class CrashActivity extends AppCompatActivity {
         }
     }
 
-    private static class Crash {
+    @VisibleForTesting
+    static class Crash {
         final int title;
 
         final int description;

--- a/apps/sasquatch/src/main/res/values/crashes.xml
+++ b/apps/sasquatch/src/main/res/values/crashes.xml
@@ -2,7 +2,8 @@
 <resources>
     <string name="title_test_crash">Test crash</string>
     <string name="description_test_crash">Using Crash.generateTestCrash() API</string>
-    <string name="title_crash_divide_by_0">Device by 0</string>
+    <string name="title_crash_divide_by_0">Divide by 0</string>
+    <string name="description_crash_divide_by_0">Divide by 0</string>
     <string name="title_test_ui_crash">Test some UI crash</string>
     <string name="description_test_ui_crash">A UI coding mistake, has inner exception</string>
     <string name="title_stack_overflow_crash">Stack overflow crash</string>


### PR DESCRIPTION
We can't truly restart application in tests, so my solution is save handled exception info after crash happened, reset mobile center singletons and restart activity.
Also, some kind of crashes can't be tested by this method.