### PR TITLE
Fixed http response leak

### DIFF
--- a/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/MainActivity.java
+++ b/apps/sasquatch/src/main/java/com/microsoft/azure/mobile/sasquatch/activities/MainActivity.java
@@ -65,6 +65,7 @@ public class MainActivity extends AppCompatActivity {
 
         sSharedPreferences = getSharedPreferences("Sasquatch", Context.MODE_PRIVATE);
         StrictMode.setThreadPolicy(new StrictMode.ThreadPolicy.Builder().detectDiskReads().detectDiskWrites().build());
+        StrictMode.setVmPolicy(new StrictMode.VmPolicy.Builder().detectAll().build());
 
         /* Set custom log URL if one was configured in settings. */
         String logUrl = sSharedPreferences.getString(LOG_URL_KEY, getString(R.string.log_url));

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/http/DefaultHttpClient.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/http/DefaultHttpClient.java
@@ -84,12 +84,16 @@ public class DefaultHttpClient implements HttpClient {
             stream = urlConnection.getInputStream();
         else
             stream = urlConnection.getErrorStream();
-        InputStreamReader in = new InputStreamReader(stream, CHARSET_NAME);
-        char[] buffer = new char[READ_BUFFER_SIZE];
-        int len;
-        while ((len = in.read(buffer)) > 0)
-            builder.append(buffer, 0, len);
-        return builder.toString();
+        try {
+            InputStreamReader in = new InputStreamReader(stream, CHARSET_NAME);
+            char[] buffer = new char[READ_BUFFER_SIZE];
+            int len;
+            while ((len = in.read(buffer)) > 0)
+                builder.append(buffer, 0, len);
+            return builder.toString();
+        } finally {
+            stream.close();
+        }
     }
 
     private static String doCall(String urlString, String method, Map<String, String> headers, CallTemplate callTemplate) throws Exception {


### PR DESCRIPTION
With the new strict mode line and without the http patch you would see:

```
05-08 18:26:36.692 10407-10416/com.microsoft.azure.mobile.sasquatch.project E/StrictMode: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
                                                                                          java.lang.Throwable: Explicit termination method 'end' not called
                                                                                              at dalvik.system.CloseGuard.open(CloseGuard.java:180)
                                                                                              at java.util.zip.Inflater.<init>(Inflater.java:104)
                                                                                              at com.android.okhttp.okio.GzipSource.<init>(GzipSource.java:62)
                                                                                              at com.android.okhttp.internal.http.HttpEngine.unzip(HttpEngine.java:645)
                                                                                              at com.android.okhttp.internal.http.HttpEngine.readResponse(HttpEngine.java:821)
                                                                                              at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:463)
                                                                                              at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponse(HttpURLConnectionImpl.java:405)
                                                                                              at com.android.okhttp.internal.huc.HttpURLConnectionImpl.getResponseCode(HttpURLConnectionImpl.java:521)
                                                                                              at com.android.okhttp.internal.huc.DelegatingHttpsURLConnection.getResponseCode(DelegatingHttpsURLConnection.java:105)
                                                                                              at com.android.okhttp.internal.huc.HttpsURLConnectionImpl.getResponseCode(HttpsURLConnectionImpl.java)
                                                                                              at com.microsoft.azure.mobile.http.DefaultHttpClient.doCall(DefaultHttpClient.java:135)
                                                                                              at com.microsoft.azure.mobile.http.DefaultHttpClient.access$000(DefaultHttpClient.java:21)
                                                                                              at com.microsoft.azure.mobile.http.DefaultHttpClient$Call.doInBackground(DefaultHttpClient.java:211)
                                                                                              at com.microsoft.azure.mobile.http.DefaultHttpClient$Call.doInBackground(DefaultHttpClient.java:187)
                                                                                              at android.os.AsyncTask$2.call(AsyncTask.java:305)
                                                                                              at java.util.concurrent.FutureTask.run(FutureTask.java:237)
                                                                                              at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1133)
                                                                                              at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:607)
                                                                                              at java.lang.Thread.run(Thread.java:761)
```