### PR TITLE
Fix a crash when calling AnyService.isEnabled() before start

### DIFF
--- a/sdk/mobile-center-analytics/src/androidTest/java/com/microsoft/azure/mobile/analytics/AnalyticsAndroidTest.java
+++ b/sdk/mobile-center-analytics/src/androidTest/java/com/microsoft/azure/mobile/analytics/AnalyticsAndroidTest.java
@@ -1,10 +1,11 @@
 package com.microsoft.azure.mobile.analytics;
 
 import android.annotation.SuppressLint;
+import android.app.Application;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 
-import com.microsoft.azure.mobile.Constants;
+import com.microsoft.azure.mobile.MobileCenter;
 import com.microsoft.azure.mobile.analytics.channel.AnalyticsListener;
 import com.microsoft.azure.mobile.analytics.ingestion.models.EventLog;
 import com.microsoft.azure.mobile.channel.Channel;
@@ -41,8 +42,7 @@ public class AnalyticsAndroidTest {
     public static void setUpClass() {
         MobileCenterLog.setLogLevel(android.util.Log.VERBOSE);
         sContext = InstrumentationRegistry.getContext();
-        Constants.loadFromContext(sContext);
-        StorageHelper.initialize(sContext);
+        MobileCenter.configure((Application) sContext.getApplicationContext(), "dummy");
     }
 
     @Before
@@ -54,7 +54,6 @@ public class AnalyticsAndroidTest {
 
     @Test
     public void testAnalyticsListener() {
-
         AnalyticsListener analyticsListener = mock(AnalyticsListener.class);
         Analytics.setListener(analyticsListener);
         Channel channel = mock(Channel.class);

--- a/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/CrashesAndroidTest.java
+++ b/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/CrashesAndroidTest.java
@@ -1,10 +1,11 @@
 package com.microsoft.azure.mobile.crashes;
 
 import android.annotation.SuppressLint;
+import android.app.Application;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 
-import com.microsoft.azure.mobile.Constants;
+import com.microsoft.azure.mobile.MobileCenter;
 import com.microsoft.azure.mobile.ResultCallback;
 import com.microsoft.azure.mobile.channel.Channel;
 import com.microsoft.azure.mobile.crashes.ingestion.models.ManagedErrorLog;
@@ -55,8 +56,7 @@ public class CrashesAndroidTest {
     public static void setUpClass() {
         MobileCenterLog.setLogLevel(android.util.Log.VERBOSE);
         sContext = InstrumentationRegistry.getContext();
-        Constants.loadFromContext(sContext);
-        StorageHelper.initialize(sContext);
+        MobileCenter.configure((Application) sContext.getApplicationContext(), "dummy");
         sDefaultCrashHandler = Thread.getDefaultUncaughtExceptionHandler();
     }
 

--- a/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManagerAndroidTest.java
+++ b/sdk/mobile-center-crashes/src/androidTest/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManagerAndroidTest.java
@@ -1,9 +1,10 @@
 package com.microsoft.azure.mobile.crashes;
 
+import android.app.Application;
 import android.content.Context;
 import android.support.test.InstrumentationRegistry;
 
-import com.microsoft.azure.mobile.Constants;
+import com.microsoft.azure.mobile.MobileCenter;
 import com.microsoft.azure.mobile.crashes.utils.ErrorLogHelper;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
 import com.microsoft.azure.mobile.utils.storage.StorageHelper;
@@ -27,8 +28,7 @@ public class WrapperSdkExceptionManagerAndroidTest {
     public static void setUpClass() {
         MobileCenterLog.setLogLevel(android.util.Log.VERBOSE);
         Context context = InstrumentationRegistry.getContext();
-        Constants.loadFromContext(context);
-        StorageHelper.initialize(context);
+        MobileCenter.configure((Application) context.getApplicationContext(), "dummy");
     }
 
     @Before

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/UncaughtExceptionHandlerTest.java
@@ -1,15 +1,16 @@
 package com.microsoft.azure.mobile.crashes;
 
+import android.app.Application;
 import android.content.Context;
 import android.os.SystemClock;
 
+import com.microsoft.azure.mobile.MobileCenter;
 import com.microsoft.azure.mobile.crashes.ingestion.models.ManagedErrorLog;
 import com.microsoft.azure.mobile.crashes.utils.ErrorLogHelper;
 import com.microsoft.azure.mobile.ingestion.models.Log;
 import com.microsoft.azure.mobile.ingestion.models.json.LogSerializer;
 import com.microsoft.azure.mobile.utils.DeviceInfoHelper;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
-import com.microsoft.azure.mobile.utils.PrefStorageConstants;
 import com.microsoft.azure.mobile.utils.ShutdownHelper;
 import com.microsoft.azure.mobile.utils.storage.StorageHelper;
 
@@ -31,6 +32,7 @@ import java.io.IOException;
 import java.util.Map;
 import java.util.UUID;
 
+import static com.microsoft.azure.mobile.utils.PrefStorageConstants.KEY_ENABLED;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNull;
 import static org.mockito.Matchers.any;
@@ -50,7 +52,7 @@ import static org.powermock.api.mockito.PowerMockito.when;
 @PrepareForTest({SystemClock.class, StorageHelper.PreferencesStorage.class, StorageHelper.InternalStorage.class, Crashes.class, ErrorLogHelper.class, DeviceInfoHelper.class, ShutdownHelper.class, MobileCenterLog.class})
 public class UncaughtExceptionHandlerTest {
 
-    private static final String CRASHES_ENABLED_KEY = PrefStorageConstants.KEY_ENABLED + "_" + Crashes.getInstance().getServiceName();
+    private static final String CRASHES_ENABLED_KEY = KEY_ENABLED + "_" + Crashes.getInstance().getServiceName();
 
     @Rule
     public PowerMockRule mPowerMockRule = new PowerMockRule();
@@ -70,6 +72,7 @@ public class UncaughtExceptionHandlerTest {
         mockStatic(DeviceInfoHelper.class);
         mockStatic(System.class);
 
+        when(StorageHelper.PreferencesStorage.getBoolean(KEY_ENABLED, true)).thenReturn(true);
         when(StorageHelper.PreferencesStorage.getBoolean(CRASHES_ENABLED_KEY, true)).thenReturn(true);
 
         /* Then simulate further changes to state. */
@@ -96,6 +99,8 @@ public class UncaughtExceptionHandlerTest {
         mDefaultExceptionHandler = mock(Thread.UncaughtExceptionHandler.class);
         Thread.setDefaultUncaughtExceptionHandler(mDefaultExceptionHandler);
         mExceptionHandler = new UncaughtExceptionHandler();
+
+        MobileCenter.configure(mock(Application.class), "dummy");
     }
 
     @Test
@@ -119,7 +124,6 @@ public class UncaughtExceptionHandlerTest {
     }
 
     @Test
-    @SuppressWarnings("WeakerAccess")
     public void handleExceptionAndPassOn() {
         mExceptionHandler.register();
 

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/AbstractMobileCenterService.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/AbstractMobileCenterService.java
@@ -60,7 +60,7 @@ public abstract class AbstractMobileCenterService implements MobileCenterService
 
     @Override
     public synchronized boolean isInstanceEnabled() {
-        return StorageHelper.PreferencesStorage.getBoolean(getEnabledPreferenceKey(), true);
+        return MobileCenter.isEnabled() && StorageHelper.PreferencesStorage.getBoolean(getEnabledPreferenceKey(), true);
     }
 
     @Override

--- a/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/MobileCenter.java
+++ b/sdk/mobile-center/src/main/java/com/microsoft/azure/mobile/MobileCenter.java
@@ -308,7 +308,7 @@ public class MobileCenter {
         queueCustomProperties(properties);
     }
 
-     /**
+    /**
      * {@link #isConfigured()} implementation at instance level.
      */
     private synchronized boolean isInstanceConfigured() {
@@ -491,8 +491,10 @@ public class MobileCenter {
             mUncaughtExceptionHandler.unregister();
         }
 
-        /* Update state. */
-        StorageHelper.PreferencesStorage.putBoolean(PrefStorageConstants.KEY_ENABLED, enabled);
+        /* Update state now if true, services are checking this. */
+        if (enabled) {
+            StorageHelper.PreferencesStorage.putBoolean(PrefStorageConstants.KEY_ENABLED, true);
+        }
 
         /* Apply change to services. */
         for (MobileCenterService service : mServices) {
@@ -506,6 +508,11 @@ public class MobileCenter {
             /* Forward status change. */
             if (service.isInstanceEnabled() != enabled)
                 service.setInstanceEnabled(enabled);
+        }
+
+        /* Update state now if false, services are checking if enabled while disabling. */
+        if (!enabled) {
+            StorageHelper.PreferencesStorage.putBoolean(PrefStorageConstants.KEY_ENABLED, false);
         }
 
         /* Log current state. */

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/AbstractMobileCenterServiceTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/AbstractMobileCenterServiceTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.verifyNoMoreInteractions;
@@ -114,7 +115,7 @@ public class AbstractMobileCenterServiceTest {
     }
 
     @Test
-    public void setEnabled() {
+    public void setEnabledIfCoreEnabled() {
         assertTrue(service.isInstanceEnabled());
         service.setInstanceEnabled(true);
         service.setInstanceEnabled(false);
@@ -127,6 +128,19 @@ public class AbstractMobileCenterServiceTest {
         StorageHelper.PreferencesStorage.putBoolean(service.getEnabledPreferenceKey(), false);
         verifyStatic();
         StorageHelper.PreferencesStorage.putBoolean(service.getEnabledPreferenceKey(), true);
+    }
+
+    @Test
+    public void setEnabledIfCoreDisabled() {
+        when(MobileCenter.isEnabled()).thenReturn(false);
+        assertFalse(service.isInstanceEnabled());
+        service.setInstanceEnabled(true);
+        assertFalse(service.isInstanceEnabled());
+        service.setInstanceEnabled(false);
+        assertFalse(service.isInstanceEnabled());
+        service.setInstanceEnabled(true);
+        verifyStatic(never());
+        StorageHelper.PreferencesStorage.putBoolean(eq(service.getEnabledPreferenceKey()), anyBoolean());
     }
 
     @Test

--- a/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/MobileCenterTest.java
+++ b/sdk/mobile-center/src/test/java/com/microsoft/azure/mobile/MobileCenterTest.java
@@ -557,10 +557,10 @@ public class MobileCenterTest {
         MobileCenter.start(application, DUMMY_APP_SECRET, DummyService.class, AnotherDummyService.class);
         MobileCenter mobileCenter = MobileCenter.getInstance();
 
-        /* Verify services are enabled by default but MobileCenter is disabled. */
+        /* Verify services are disabled by default if MobileCenter is disabled. */
         assertFalse(MobileCenter.isEnabled());
         for (MobileCenterService service : mobileCenter.getServices()) {
-            assertTrue(service.isInstanceEnabled());
+            assertFalse(service.isInstanceEnabled());
             verify(application, never()).registerActivityLifecycleCallbacks(service);
         }
 
@@ -572,6 +572,21 @@ public class MobileCenterTest {
             verify(application).registerActivityLifecycleCallbacks(service);
             verify(application, never()).unregisterActivityLifecycleCallbacks(service);
         }
+    }
+
+    @Test
+    public void disabledBeforeStart() {
+        when(StorageHelper.PreferencesStorage.getBoolean(KEY_ENABLED, true)).thenReturn(true);
+        MobileCenter mobileCenter = MobileCenter.getInstance();
+
+        /* Verify services are disabled if called before start (no access to storage). */
+        assertFalse(MobileCenter.isEnabled());
+        assertFalse(DummyService.getInstance().isInstanceEnabled());
+
+        /* Verify we can not enable until start. */
+        MobileCenter.setEnabled(true);
+        assertFalse(MobileCenter.isEnabled());
+        assertFalse(DummyService.getInstance().isInstanceEnabled());
     }
 
     @Test


### PR DESCRIPTION
This returns false and prints an error now.