### PR TITLE
Use PackageManager.canRequestPackageInstalls() on Android O

### DIFF
--- a/sdk/build.gradle
+++ b/sdk/build.gradle
@@ -29,6 +29,9 @@ subprojects {
 
         defaultConfig {
             consumerProguardFiles 'proguard-rules.pro'
+
+            buildConfigField 'int', "MIN_SDK_VERSION", "${ext.minSdkVersion}"
+            buildConfigField 'int', "TARGET_SDK_VERSION", "${ext.targetSdkVersion}"
         }
 
         buildTypes {

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -17,6 +17,7 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
+import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.SystemClock;
@@ -1085,7 +1086,7 @@ public class Distribute extends AbstractMobileCenterService {
 
             @Override
             public void onClick(DialogInterface dialog, int which) {
-                goToSettings(releaseDetails);
+                goToUnknownAppsSettings(releaseDetails);
             }
         });
         mUnknownSourcesDialog = dialogBuilder.create();
@@ -1093,11 +1094,18 @@ public class Distribute extends AbstractMobileCenterService {
     }
 
     /**
-     * Navigate to secure settings.
+     * Navigate to security settings or application settings on Android O.
      *
      * @param releaseDetails release details to check for state change.
      */
-    private synchronized void goToSettings(ReleaseDetails releaseDetails) {
+    private synchronized void goToUnknownAppsSettings(ReleaseDetails releaseDetails) {
+        Intent intent;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            intent = new Intent(Settings.ACTION_MANAGE_UNKNOWN_APP_SOURCES);
+            intent.setData(Uri.parse("package:" + mForegroundActivity.getPackageName()));
+        } else {
+            intent = new Intent(Settings.ACTION_SECURITY_SETTINGS);
+        }
         try {
 
             /*
@@ -1105,7 +1113,7 @@ public class Distribute extends AbstractMobileCenterService {
              * And a no U.I. activity of our own must finish in onCreate,
              * so it cannot receive a result.
              */
-            mForegroundActivity.startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS));
+            mForegroundActivity.startActivity(intent);
         } catch (ActivityNotFoundException e) {
 
             /* On some devices, it's not possible, user will do it by himself. */

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/InstallerUtils.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/InstallerUtils.java
@@ -70,11 +70,12 @@ class InstallerUtils {
      */
     @SuppressWarnings("deprecation")
     static boolean isUnknownSourcesEnabled(@NonNull Context context) {
-        ContentResolver contentResolver = context.getContentResolver();
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
-            return INSTALL_NON_MARKET_APPS_ENABLED.equals(Settings.Global.getString(contentResolver, Settings.Global.INSTALL_NON_MARKET_APPS));
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            return context.getPackageManager().canRequestPackageInstalls();
+        } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && Build.VERSION.SDK_INT < Build.VERSION_CODES.LOLLIPOP) {
+            return INSTALL_NON_MARKET_APPS_ENABLED.equals(Settings.Global.getString(context.getContentResolver(), Settings.Global.INSTALL_NON_MARKET_APPS));
         } else {
-            return INSTALL_NON_MARKET_APPS_ENABLED.equals(Settings.Secure.getString(contentResolver, Settings.Secure.INSTALL_NON_MARKET_APPS));
+            return INSTALL_NON_MARKET_APPS_ENABLED.equals(Settings.Secure.getString(context.getContentResolver(), Settings.Secure.INSTALL_NON_MARKET_APPS));
         }
     }
 }

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/UnknownSourcesDetectionTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/UnknownSourcesDetectionTest.java
@@ -33,7 +33,7 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Build.class, Settings.Global.class, Settings.Secure.class})
 public class UnknownSourcesDetectionTest {
-    
+
     @Mock
     private Context mContext;
 
@@ -56,7 +56,7 @@ public class UnknownSourcesDetectionTest {
         when(Settings.Secure.getString(any(ContentResolver.class), eq(Settings.Secure.INSTALL_NON_MARKET_APPS))).thenReturn(null);
         when(Settings.Global.getString(any(ContentResolver.class), eq(Settings.Global.INSTALL_NON_MARKET_APPS))).thenReturn(null);
         when(mPackageManager.canRequestPackageInstalls()).thenReturn(true);
-        for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
+        for (int apiLevel = BuildConfig.MIN_SDK_VERSION; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
             mockApiLevel(apiLevel);
             assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager, never()).canRequestPackageInstalls();
@@ -71,7 +71,7 @@ public class UnknownSourcesDetectionTest {
             assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager, never()).canRequestPackageInstalls();
         }
-        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= Build.VERSION_CODES.O; apiLevel++) {
+        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= BuildConfig.TARGET_SDK_VERSION; apiLevel++) {
             mockApiLevel(apiLevel);
             assertTrue(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager).canRequestPackageInstalls();
@@ -84,7 +84,7 @@ public class UnknownSourcesDetectionTest {
         when(Settings.Secure.getString(any(ContentResolver.class), eq(Settings.Secure.INSTALL_NON_MARKET_APPS))).thenReturn(INSTALL_NON_MARKET_APPS_ENABLED);
         when(Settings.Global.getString(any(ContentResolver.class), eq(Settings.Global.INSTALL_NON_MARKET_APPS))).thenReturn(null);
         when(mPackageManager.canRequestPackageInstalls()).thenReturn(false);
-        for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
+        for (int apiLevel = BuildConfig.MIN_SDK_VERSION; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
             mockApiLevel(apiLevel);
             assertTrue(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager, never()).canRequestPackageInstalls();
@@ -99,7 +99,7 @@ public class UnknownSourcesDetectionTest {
             assertTrue(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager, never()).canRequestPackageInstalls();
         }
-        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= Build.VERSION_CODES.O; apiLevel++) {
+        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= BuildConfig.TARGET_SDK_VERSION; apiLevel++) {
             mockApiLevel(apiLevel);
             assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager).canRequestPackageInstalls();
@@ -112,7 +112,7 @@ public class UnknownSourcesDetectionTest {
         when(Settings.Global.getString(any(ContentResolver.class), eq(Settings.Global.INSTALL_NON_MARKET_APPS))).thenReturn(INSTALL_NON_MARKET_APPS_ENABLED);
         when(Settings.Secure.getString(any(ContentResolver.class), eq(Settings.Secure.INSTALL_NON_MARKET_APPS))).thenReturn(null);
         when(mPackageManager.canRequestPackageInstalls()).thenReturn(false);
-        for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
+        for (int apiLevel = BuildConfig.MIN_SDK_VERSION; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
             mockApiLevel(apiLevel);
             assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager, never()).canRequestPackageInstalls();
@@ -127,7 +127,7 @@ public class UnknownSourcesDetectionTest {
             assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager, never()).canRequestPackageInstalls();
         }
-        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= Build.VERSION_CODES.O; apiLevel++) {
+        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= BuildConfig.TARGET_SDK_VERSION; apiLevel++) {
             mockApiLevel(apiLevel);
             assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
             verify(mPackageManager).canRequestPackageInstalls();
@@ -140,7 +140,7 @@ public class UnknownSourcesDetectionTest {
         for (String value : Arrays.asList(null, "", "0", "on", "true", "TRUE")) {
             when(Settings.Global.getString(any(ContentResolver.class), eq(Settings.Global.INSTALL_NON_MARKET_APPS))).thenReturn(value);
             when(Settings.Secure.getString(any(ContentResolver.class), eq(Settings.Secure.INSTALL_NON_MARKET_APPS))).thenReturn(value);
-            for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel < Build.VERSION_CODES.O; apiLevel++) {
+            for (int apiLevel = BuildConfig.MIN_SDK_VERSION; apiLevel < Build.VERSION_CODES.O; apiLevel++) {
                 mockApiLevel(apiLevel);
                 assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
             }

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/UnknownSourcesDetectionTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/UnknownSourcesDetectionTest.java
@@ -3,12 +3,14 @@ package com.microsoft.azure.mobile.distribute;
 import android.annotation.SuppressLint;
 import android.content.ContentResolver;
 import android.content.Context;
+import android.content.pm.PackageManager;
 import android.os.Build;
 import android.provider.Settings;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.powermock.reflect.Whitebox;
@@ -20,7 +22,9 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.powermock.api.mockito.PowerMockito.mockStatic;
 
@@ -29,6 +33,12 @@ import static org.powermock.api.mockito.PowerMockito.mockStatic;
 @RunWith(PowerMockRunner.class)
 @PrepareForTest({Build.class, Settings.Global.class, Settings.Secure.class})
 public class UnknownSourcesDetectionTest {
+    
+    @Mock
+    private Context mContext;
+
+    @Mock
+    private PackageManager mPackageManager;
 
     private static void mockApiLevel(int apiLevel) {
         Whitebox.setInternalState(Build.VERSION.class, "SDK_INT", apiLevel);
@@ -38,23 +48,62 @@ public class UnknownSourcesDetectionTest {
     public void setUp() {
         mockStatic(Settings.Global.class);
         mockStatic(Settings.Secure.class);
+        when(mContext.getPackageManager()).thenReturn(mPackageManager);
+    }
+
+    @Test
+    public void unknownSourcesEnabledViaPackageManager() {
+        when(Settings.Secure.getString(any(ContentResolver.class), eq(Settings.Secure.INSTALL_NON_MARKET_APPS))).thenReturn(null);
+        when(Settings.Global.getString(any(ContentResolver.class), eq(Settings.Global.INSTALL_NON_MARKET_APPS))).thenReturn(null);
+        when(mPackageManager.canRequestPackageInstalls()).thenReturn(true);
+        for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
+            mockApiLevel(apiLevel);
+            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
+        }
+        for (int apiLevel = Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel < Build.VERSION_CODES.LOLLIPOP; apiLevel++) {
+            mockApiLevel(apiLevel);
+            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
+        }
+        for (int apiLevel = Build.VERSION_CODES.LOLLIPOP; apiLevel < Build.VERSION_CODES.O; apiLevel++) {
+            mockApiLevel(apiLevel);
+            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
+        }
+        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= Build.VERSION_CODES.O; apiLevel++) {
+            mockApiLevel(apiLevel);
+            assertTrue(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager).canRequestPackageInstalls();
+            reset(mPackageManager);
+        }
     }
 
     @Test
     public void unknownSourcesEnabledViaSystemSecure() {
         when(Settings.Secure.getString(any(ContentResolver.class), eq(Settings.Secure.INSTALL_NON_MARKET_APPS))).thenReturn(INSTALL_NON_MARKET_APPS_ENABLED);
         when(Settings.Global.getString(any(ContentResolver.class), eq(Settings.Global.INSTALL_NON_MARKET_APPS))).thenReturn(null);
+        when(mPackageManager.canRequestPackageInstalls()).thenReturn(false);
         for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
             mockApiLevel(apiLevel);
-            assertTrue(InstallerUtils.isUnknownSourcesEnabled(mock(Context.class)));
+            assertTrue(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
         }
         for (int apiLevel = Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel < Build.VERSION_CODES.LOLLIPOP; apiLevel++) {
             mockApiLevel(apiLevel);
-            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mock(Context.class)));
+            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
         }
-        for (int apiLevel = Build.VERSION_CODES.LOLLIPOP; apiLevel <= Build.VERSION_CODES.N_MR1; apiLevel++) {
+        for (int apiLevel = Build.VERSION_CODES.LOLLIPOP; apiLevel < Build.VERSION_CODES.O; apiLevel++) {
             mockApiLevel(apiLevel);
-            assertTrue(InstallerUtils.isUnknownSourcesEnabled(mock(Context.class)));
+            assertTrue(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
+        }
+        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= Build.VERSION_CODES.O; apiLevel++) {
+            mockApiLevel(apiLevel);
+            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager).canRequestPackageInstalls();
+            reset(mPackageManager);
         }
     }
 
@@ -62,17 +111,27 @@ public class UnknownSourcesDetectionTest {
     public void unknownSourcesEnabledViaSystemGlobal() {
         when(Settings.Global.getString(any(ContentResolver.class), eq(Settings.Global.INSTALL_NON_MARKET_APPS))).thenReturn(INSTALL_NON_MARKET_APPS_ENABLED);
         when(Settings.Secure.getString(any(ContentResolver.class), eq(Settings.Secure.INSTALL_NON_MARKET_APPS))).thenReturn(null);
+        when(mPackageManager.canRequestPackageInstalls()).thenReturn(false);
         for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel < Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel++) {
             mockApiLevel(apiLevel);
-            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mock(Context.class)));
+            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
         }
         for (int apiLevel = Build.VERSION_CODES.JELLY_BEAN_MR1; apiLevel < Build.VERSION_CODES.LOLLIPOP; apiLevel++) {
             mockApiLevel(apiLevel);
-            assertTrue(InstallerUtils.isUnknownSourcesEnabled(mock(Context.class)));
+            assertTrue(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
         }
-        for (int apiLevel = Build.VERSION_CODES.LOLLIPOP; apiLevel <= Build.VERSION_CODES.N_MR1; apiLevel++) {
+        for (int apiLevel = Build.VERSION_CODES.LOLLIPOP; apiLevel < Build.VERSION_CODES.O; apiLevel++) {
             mockApiLevel(apiLevel);
-            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mock(Context.class)));
+            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager, never()).canRequestPackageInstalls();
+        }
+        for (int apiLevel = Build.VERSION_CODES.O; apiLevel <= Build.VERSION_CODES.O; apiLevel++) {
+            mockApiLevel(apiLevel);
+            assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
+            verify(mPackageManager).canRequestPackageInstalls();
+            reset(mPackageManager);
         }
     }
 
@@ -81,9 +140,9 @@ public class UnknownSourcesDetectionTest {
         for (String value : Arrays.asList(null, "", "0", "on", "true", "TRUE")) {
             when(Settings.Global.getString(any(ContentResolver.class), eq(Settings.Global.INSTALL_NON_MARKET_APPS))).thenReturn(value);
             when(Settings.Secure.getString(any(ContentResolver.class), eq(Settings.Secure.INSTALL_NON_MARKET_APPS))).thenReturn(value);
-            for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel <= Build.VERSION_CODES.N_MR1; apiLevel++) {
+            for (int apiLevel = Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1; apiLevel < Build.VERSION_CODES.O; apiLevel++) {
                 mockApiLevel(apiLevel);
-                assertFalse(InstallerUtils.isUnknownSourcesEnabled(mock(Context.class)));
+                assertFalse(InstallerUtils.isUnknownSourcesEnabled(mContext));
             }
         }
     }


### PR DESCRIPTION
> Starting from O, apps should use canRequestPackageInstalls()

https://developer.android.com/reference/android/provider/Settings.Secure.html#INSTALL_NON_MARKET_APPS