### PR TITLE
Wrapper SDK changes for Crashes

### DIFF
--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/Crashes.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/Crashes.java
@@ -32,6 +32,9 @@ import org.json.JSONException;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
@@ -145,6 +148,11 @@ public class Crashes extends AbstractMobileCenterService {
      * Flag to remember whether we already saved uncaught exception or not.
      */
     private boolean mSavedUncaughtException;
+
+    /**
+     * Automatic processing flag (automatic is the default).
+     */
+    private boolean mAutomaticProcessing = true;
 
     /**
      * Init.
@@ -511,19 +519,8 @@ public class Crashes extends AbstractMobileCenterService {
         }
     }
 
-    private boolean shouldStopProcessingPendingErrors() {
-        if (!isInstanceEnabled()) {
-            MobileCenterLog.info(LOG_TAG, "Crashes service is disabled while processing errors. Cancel processing all pending errors.");
-            return true;
-        }
-        return false;
-    }
-
     private void processPendingErrors() {
         for (File logFile : ErrorLogHelper.getStoredErrorLogFiles()) {
-            if (shouldStopProcessingPendingErrors()) {
-                return;
-            }
             MobileCenterLog.debug(LOG_TAG, "Process pending error file: " + logFile);
             String logfileContents = StorageHelper.InternalStorage.read(logFile);
             if (logfileContents != null) {
@@ -533,8 +530,10 @@ public class Crashes extends AbstractMobileCenterService {
                     ErrorReport report = buildErrorReport(log);
                     if (report == null) {
                         removeAllStoredErrorLogFiles(id);
-                    } else if (mCrashesListener.shouldProcess(report)) {
-                        MobileCenterLog.debug(LOG_TAG, "CrashesListener.shouldProcess returned true, continue processing log: " + id.toString());
+                    } else if (!mAutomaticProcessing || mCrashesListener.shouldProcess(report)) {
+                        if (!mAutomaticProcessing) {
+                            MobileCenterLog.debug(LOG_TAG, "CrashesListener.shouldProcess returned true, continue processing log: " + id.toString());
+                        }
                         mUnprocessedErrorReports.put(id, mErrorReportCache.get(id));
                     } else {
                         MobileCenterLog.debug(LOG_TAG, "CrashesListener.shouldProcess returned false, clean up and ignore log: " + id.toString());
@@ -546,11 +545,13 @@ public class Crashes extends AbstractMobileCenterService {
             }
         }
 
-        if (shouldStopProcessingPendingErrors()) {
-            return;
+        /* If automatic processing is enabled. */
+        if (mAutomaticProcessing) {
+
+            /* Proceed to check if user confirmation is needed. */
+            processUserConfirmation();
         }
 
-        processUserConfirmation();
     }
 
     private void processUserConfirmation() {
@@ -642,6 +643,8 @@ public class Crashes extends AbstractMobileCenterService {
 
             @Override
             public void run() {
+
+                /* If we don't send. */
                 if (userConfirmation == DONT_SEND) {
 
                     /* Clean up all pending error log and throwable files. */
@@ -650,23 +653,30 @@ public class Crashes extends AbstractMobileCenterService {
                         iterator.remove();
                         removeAllStoredErrorLogFiles(id);
                     }
-                } else {
+                }
 
+                /* We send the crash. */
+                else {
+
+                    /* Always send: we remember. */
                     if (userConfirmation == ALWAYS_SEND) {
                         StorageHelper.PreferencesStorage.putBoolean(PREF_KEY_ALWAYS_SEND, true);
                     }
 
+                    /* Send every pending report. */
                     Iterator<Map.Entry<UUID, ErrorLogReport>> unprocessedIterator = mUnprocessedErrorReports.entrySet().iterator();
                     while (unprocessedIterator.hasNext()) {
-                        if (shouldStopProcessingPendingErrors()) {
-                            break;
-                        }
+
+                        /* Send report. */
                         Map.Entry<UUID, ErrorLogReport> unprocessedEntry = unprocessedIterator.next();
                         ErrorLogReport errorLogReport = unprocessedEntry.getValue();
                         mChannel.enqueue(errorLogReport.log, ERROR_GROUP);
 
+                        /* Get attachments from callback. */
                         Iterable<ErrorAttachmentLog> attachments = mCrashesListener.getErrorAttachments(errorLogReport.report);
-                        handleErrorAttachmentLogs(attachments, errorLogReport);
+
+                        /* And send them. */
+                        sendErrorAttachment(errorLogReport.log.getId(), attachments);
 
                         /* Clean up an error log file and map entry. */
                         unprocessedIterator.remove();
@@ -677,15 +687,18 @@ public class Crashes extends AbstractMobileCenterService {
         });
     }
 
-    private void handleErrorAttachmentLogs(Iterable<ErrorAttachmentLog> attachments, ErrorLogReport errorLogReport) {
+    /**
+     * Send error attachment logs through channel.
+     */
+    private void sendErrorAttachment(UUID errorId, Iterable<ErrorAttachmentLog> attachments) {
         if (attachments == null) {
-            MobileCenterLog.debug(LOG_TAG, "CrashesListener.getErrorAttachments returned null, no additional information will be attached to log: " + errorLogReport.log.getId().toString());
+            MobileCenterLog.debug(LOG_TAG, "CrashesListener.getErrorAttachments returned null, no additional information will be attached to log: " + errorId.toString());
         } else {
             int totalErrorAttachments = 0;
             for (ErrorAttachmentLog attachment : attachments) {
                 if (attachment != null) {
                     attachment.setId(UUID.randomUUID());
-                    attachment.setErrorId(errorLogReport.log.getId());
+                    attachment.setErrorId(errorId);
                     if (attachment.isValid()) {
                         ++totalErrorAttachments;
                         mChannel.enqueue(attachment, ERROR_GROUP);
@@ -775,6 +788,85 @@ public class Crashes extends AbstractMobileCenterService {
             MobileCenterLog.debug(Crashes.LOG_TAG, "Saved empty Throwable file in " + throwableFile);
         }
         return errorLogId;
+    }
+
+    /**
+     * Set automatic processing flag.
+     */
+    void setAutomaticProcessing(boolean automaticProcessing) {
+        mAutomaticProcessing = automaticProcessing;
+    }
+
+    /**
+     * Get unprocessed error reports, used when automatic processing is disabled.
+     */
+    MobileCenterFuture<Collection<ErrorReport>> getUnprocessedErrorReports() {
+        final DefaultMobileCenterFuture<Collection<ErrorReport>> future = new DefaultMobileCenterFuture<>();
+        postAsyncGetter(new Runnable() {
+
+            @Override
+            public void run() {
+                Collection<ErrorReport> reports = new ArrayList<>(mUnprocessedErrorReports.size());
+                for (ErrorLogReport entry : mUnprocessedErrorReports.values()) {
+                    reports.add(entry.report);
+                }
+                future.complete(reports);
+            }
+        }, future, Collections.<ErrorReport>emptyList());
+        return future;
+    }
+
+    /**
+     * Used when automatic processing is disabled: resume sending or ask for user confirmation.
+     */
+    void sendCrashReportsOrAwaitUserConfirmation(final Collection<ErrorReport> filteredReports) {
+        post(new Runnable() {
+
+            @Override
+            public void run() {
+
+                /* Apply the filtering. */
+                Iterator<Map.Entry<UUID, ErrorLogReport>> iterator = mUnprocessedErrorReports.entrySet().iterator();
+                while (iterator.hasNext()) {
+                    Map.Entry<UUID, ErrorLogReport> entry = iterator.next();
+                    UUID id = entry.getKey();
+                    if (filteredReports != null && filteredReports.contains(entry.getValue().report)) {
+                        MobileCenterLog.debug(LOG_TAG, "CrashesListener.shouldProcess returned true, continue processing log: " + id.toString());
+                    } else {
+                        MobileCenterLog.debug(LOG_TAG, "CrashesListener.shouldProcess returned false, clean up and ignore log: " + id.toString());
+                        removeAllStoredErrorLogFiles(id);
+                        iterator.remove();
+                    }
+                }
+
+                /* Proceed to check if user confirmation is needed. */
+                processUserConfirmation();
+            }
+        });
+    }
+
+    /**
+     * Used when automatic processing is disabled to send error attachments.
+     */
+    void sendErrorAttachments(final String errorReportId, final Iterable<ErrorAttachmentLog> attachments) {
+        post(new Runnable() {
+
+            @Override
+            public void run() {
+
+                /* Check error identifier format. */
+                UUID errorId;
+                try {
+                    errorId = UUID.fromString(errorReportId);
+                } catch (RuntimeException e) {
+                    MobileCenterLog.error(LOG_TAG, "Error report identifier has an invalid format for sending attachments.");
+                    return;
+                }
+
+                /* Send them. */
+                sendErrorAttachment(errorId, attachments);
+            }
+        });
     }
 
     /**

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManager.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/WrapperSdkExceptionManager.java
@@ -3,12 +3,16 @@ package com.microsoft.azure.mobile.crashes;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
 
+import com.microsoft.azure.mobile.crashes.ingestion.models.ErrorAttachmentLog;
+import com.microsoft.azure.mobile.crashes.model.ErrorReport;
 import com.microsoft.azure.mobile.crashes.utils.ErrorLogHelper;
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
+import com.microsoft.azure.mobile.utils.async.MobileCenterFuture;
 import com.microsoft.azure.mobile.utils.storage.StorageHelper;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.UUID;
@@ -126,6 +130,42 @@ public class WrapperSdkExceptionManager {
      */
     public static void trackException(com.microsoft.azure.mobile.crashes.ingestion.models.Exception modelException) {
         Crashes.getInstance().queueException(modelException);
+    }
+
+    /**
+     * Disable automatic processing of crashes.
+     */
+    public static void setAutomaticProcessing(boolean automaticProcessing) {
+        Crashes.getInstance().setAutomaticProcessing(automaticProcessing);
+    }
+
+    /**
+     * Get unprocessed error reports when automatic processing is disabled.
+     *
+     * @return unprocessed error reports as an async future.
+     */
+    public static MobileCenterFuture<Collection<ErrorReport>> getUnprocessedErrorReports() {
+        return Crashes.getInstance().getUnprocessedErrorReports();
+    }
+
+    /**
+     * Resume processing of crash reports with the filtered list from {@link #getUnprocessedErrorReports()}.
+     * To use when automatic processing is disabled.
+     *
+     * @param filteredReports reports to process, every process not part of the original list are discarded.
+     */
+    public static void sendCrashReportsOrAwaitUserConfirmation(Collection<ErrorReport> filteredReports) {
+        Crashes.getInstance().sendCrashReportsOrAwaitUserConfirmation(filteredReports);
+    }
+
+    /**
+     * Send error attachments when automatic processing is disabled.
+     *
+     * @param errorReportId The crash report identifier for additional information.
+     * @param attachments   instances of {@link ErrorAttachmentLog} to be sent for the specified error report.
+     */
+    public static void sendErrorAttachments(String errorReportId, Iterable<ErrorAttachmentLog> attachments) {
+        Crashes.getInstance().sendErrorAttachments(errorReportId, attachments);
     }
 }
 

--- a/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/model/ErrorReport.java
+++ b/sdk/mobile-center-crashes/src/main/java/com/microsoft/azure/mobile/crashes/model/ErrorReport.java
@@ -8,6 +8,7 @@ import java.util.Date;
  * Error report class.
  */
 public class ErrorReport {
+
     /**
      * UUID for crash report.
      */

--- a/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/CrashesTest.java
+++ b/sdk/mobile-center-crashes/src/test/java/com/microsoft/azure/mobile/crashes/CrashesTest.java
@@ -46,14 +46,16 @@ import org.mockito.stubbing.Answer;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.rule.PowerMockRule;
-import org.powermock.reflect.Whitebox;
 
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.Date;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -438,109 +440,6 @@ public class CrashesTest {
         crashes.onStarted(mock(Context.class), "", channel);
         verifyZeroInteractions(listener);
         verify(channel, never()).enqueue(any(Log.class), anyString());
-    }
-
-    @Test
-    public void disabledDuringProcessPendingErrors() throws IOException, ClassNotFoundException, JSONException {
-        ErrorReport errorReport = ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, EXCEPTION);
-
-        File errorStorageDirectory = mock(File.class);
-        Whitebox.setInternalState(errorStorageDirectory, "path", "/");
-        when(errorStorageDirectory.listFiles()).thenReturn(new File[0]);
-        CrashesListener listener = mock(CrashesListener.class);
-        when(listener.shouldProcess(errorReport)).thenReturn(true);
-        LogSerializer logSerializer = mock(LogSerializer.class);
-        when(logSerializer.deserializeLog(anyString())).thenReturn(mErrorLog);
-        Channel channel = mock(Channel.class);
-
-        mockStatic(ErrorLogHelper.class);
-        when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)}).thenReturn(new File[]{mock(File.class)});
-        when(ErrorLogHelper.getErrorStorageDirectory()).thenReturn(errorStorageDirectory);
-        File throwableFile = mock(File.class);
-        when(throwableFile.length()).thenReturn(1L);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(throwableFile);
-        when(ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, EXCEPTION)).thenReturn(errorReport);
-
-        when(StorageHelper.InternalStorage.readObject(any(File.class))).thenReturn(EXCEPTION);
-        when(StorageHelper.InternalStorage.read(any(File.class))).thenAnswer(new Answer<String>() {
-            @Override
-            public String answer(InvocationOnMock invocation) throws Throwable {
-                Crashes.setEnabled(false);
-                return "";
-            }
-        });
-
-        /* Disabled while Crashes service is processing pending errors. */
-        Crashes crashes = Crashes.getInstance();
-        crashes.setLogSerializer(logSerializer);
-        crashes.setInstanceListener(listener);
-        crashes.onStarting(mMobileCenterHandler);
-        crashes.onStarted(mock(Context.class), "", channel);
-
-        verify(channel, never()).enqueue(any(Log.class), anyString());
-        verify(listener).shouldProcess(errorReport);
-        verifyNoMoreInteractions(listener);
-
-        /* Disabled right before handling user confirmation. */
-        Crashes.setEnabled(true);
-        Crashes.unsetInstance();
-        crashes = Crashes.getInstance();
-        crashes.setLogSerializer(logSerializer);
-        crashes.setInstanceListener(listener);
-        crashes.onStarting(mMobileCenterHandler);
-        crashes.onStarted(mock(Context.class), "", channel);
-
-        verify(channel, never()).enqueue(any(Log.class), anyString());
-        verify(listener, times(2)).shouldProcess(errorReport);
-        verifyNoMoreInteractions(listener);
-    }
-
-    @Test
-    public void disabledDuringHandleUserConfirmation() throws IOException, ClassNotFoundException, JSONException {
-        ManagedErrorLog errorLog = ErrorLogHelper.createErrorLog(mock(Context.class), Thread.currentThread(), new RuntimeException(), Thread.getAllStackTraces(), 0, true);
-        ErrorReport errorReport1 = ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, EXCEPTION);
-        ErrorReport errorReport2 = ErrorLogHelper.getErrorReportFromErrorLog(errorLog, EXCEPTION);
-
-        File errorStorageDirectory = mock(File.class);
-        Whitebox.setInternalState(errorStorageDirectory, "path", "/");
-        when(errorStorageDirectory.listFiles()).thenReturn(new File[0]);
-        CrashesListener listener = mock(CrashesListener.class);
-        when(listener.shouldProcess(any(ErrorReport.class))).thenReturn(true);
-        LogSerializer logSerializer = mock(LogSerializer.class);
-        when(logSerializer.deserializeLog(anyString())).thenReturn(mErrorLog).thenReturn(errorLog);
-        Channel channel = mock(Channel.class);
-        doAnswer(new Answer<Object>() {
-            @Override
-            public Object answer(InvocationOnMock invocation) throws Throwable {
-                Crashes.setEnabled(false);
-                return null;
-            }
-        }).when(channel).enqueue(any(Log.class), anyString());
-
-        mockStatic(ErrorLogHelper.class);
-        when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)});
-        when(ErrorLogHelper.getErrorStorageDirectory()).thenReturn(errorStorageDirectory);
-        File throwableFile = mock(File.class);
-        when(throwableFile.length()).thenReturn(1L);
-        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(throwableFile);
-        when(ErrorLogHelper.getErrorReportFromErrorLog(mErrorLog, EXCEPTION)).thenReturn(errorReport1);
-        when(ErrorLogHelper.getErrorReportFromErrorLog(errorLog, EXCEPTION)).thenReturn(errorReport2);
-
-        when(StorageHelper.InternalStorage.readObject(any(File.class))).thenReturn(EXCEPTION);
-        when(StorageHelper.InternalStorage.read(any(File.class))).thenReturn("");
-
-        Crashes crashes = Crashes.getInstance();
-        crashes.setLogSerializer(logSerializer);
-        crashes.setInstanceListener(listener);
-        crashes.onStarting(mMobileCenterHandler);
-        crashes.onStarted(mock(Context.class), "", channel);
-
-        verify(listener, times(2)).shouldProcess(any(ErrorReport.class));
-        verify(listener).shouldAwaitUserConfirmation();
-        verify(channel).enqueue(any(Log.class), anyString());
-
-        verify(listener).getErrorAttachments(any(ErrorReport.class));
-        verifyNoMoreInteractions(listener);
     }
 
     @Test
@@ -1101,5 +1000,140 @@ public class CrashesTest {
         String expectedMessage = "A limit of " + MAX_ATTACHMENT_PER_CRASH + " attachments per error report might be enforced by server.";
         PowerMockito.verifyStatic();
         MobileCenterLog.warn(Crashes.LOG_TAG, expectedMessage);
+    }
+
+    @Test
+    public void manualProcessing() throws Exception {
+
+        /* Setup mock for a crash in disk. */
+        Context mockContext = mock(Context.class);
+        Channel mockChannel = mock(Channel.class);
+        ErrorReport report1 = new ErrorReport();
+        report1.setId(UUIDUtils.randomUUID().toString());
+        ErrorReport report2 = new ErrorReport();
+        mockStatic(ErrorLogHelper.class);
+        when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)});
+        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(Throwable.class))).thenReturn(report1).thenReturn(report2);
+        when(StorageHelper.InternalStorage.read(any(File.class))).thenReturn("");
+        when(StorageHelper.InternalStorage.readObject(any(File.class))).thenReturn(new RuntimeException());
+        LogSerializer logSerializer = mock(LogSerializer.class);
+        when(logSerializer.deserializeLog(anyString())).thenAnswer(new Answer<ManagedErrorLog>() {
+
+            @Override
+            public ManagedErrorLog answer(InvocationOnMock invocation) throws Throwable {
+                ManagedErrorLog log = mock(ManagedErrorLog.class);
+                when(log.getId()).thenReturn(UUID.randomUUID());
+                return log;
+            }
+        });
+        Crashes crashes = Crashes.getInstance();
+        crashes.setLogSerializer(logSerializer);
+
+        /* Create listener for user confirmation. */
+        CrashesListener listener = mock(CrashesListener.class);
+        Crashes.setListener(listener);
+
+        /* Set manual processing. */
+        WrapperSdkExceptionManager.setAutomaticProcessing(false);
+
+        /* Start crashes. */
+        crashes.onStarting(mMobileCenterHandler);
+        crashes.onStarted(mockContext, "", mockChannel);
+
+        /* No log queued. */
+        verify(mockChannel, never()).enqueue(any(Log.class), eq(crashes.getGroupName()));
+
+        /* Get crash reports. */
+        Collection<ErrorReport> reports = WrapperSdkExceptionManager.getUnprocessedErrorReports().get();
+        assertNotNull(reports);
+        assertEquals(2, reports.size());
+        Iterator<ErrorReport> iterator = reports.iterator();
+        assertEquals(report1, iterator.next());
+        assertEquals(report2, iterator.next());
+
+        /* Listener not called yet on anything on manual processing. */
+        verifyZeroInteractions(listener);
+
+        /* Send only the first. */
+        WrapperSdkExceptionManager.sendCrashReportsOrAwaitUserConfirmation(Collections.singletonList(report1));
+
+        /* We used manual process function, listener not called. */
+        verify(listener, never()).shouldProcess(any(ErrorReport.class));
+
+        /* However it's still used after that step. */
+        verify(listener).shouldAwaitUserConfirmation();
+
+        /* 1 log sent. */
+        verify(mockChannel).enqueue(any(ManagedErrorLog.class), eq(crashes.getGroupName()));
+
+        /* We can send attachments via wrapper instead of using listener (both work but irrelevant to test with listener). */
+        ErrorAttachmentLog mockAttachment = mock(ErrorAttachmentLog.class);
+        when(mockAttachment.getId()).thenReturn(UUID.randomUUID());
+        when(mockAttachment.getData()).thenReturn(new byte[0]);
+        when(mockAttachment.isValid()).thenReturn(true);
+        WrapperSdkExceptionManager.sendErrorAttachments(report1.getId(), Collections.singletonList(mockAttachment));
+        verify(mockChannel).enqueue(eq(mockAttachment), eq(crashes.getGroupName()));
+
+        /* Send attachment with invalid UUID format for report identifier. */
+        mockAttachment = mock(ErrorAttachmentLog.class);
+        when(mockAttachment.getId()).thenReturn(UUID.randomUUID());
+        when(mockAttachment.getData()).thenReturn(new byte[0]);
+        when(mockAttachment.isValid()).thenReturn(true);
+        WrapperSdkExceptionManager.sendErrorAttachments("not-a-uuid", Collections.singletonList(mockAttachment));
+        verify(mockChannel, never()).enqueue(eq(mockAttachment), eq(crashes.getGroupName()));
+    }
+
+    @Test
+    public void manuallyReportNullList() throws Exception {
+
+        /* Setup mock for a crash in disk. */
+        Context mockContext = mock(Context.class);
+        Channel mockChannel = mock(Channel.class);
+        ErrorReport report1 = new ErrorReport();
+        report1.setId(UUIDUtils.randomUUID().toString());
+        ErrorReport report2 = new ErrorReport();
+        mockStatic(ErrorLogHelper.class);
+        when(ErrorLogHelper.getStoredErrorLogFiles()).thenReturn(new File[]{mock(File.class), mock(File.class)});
+        when(ErrorLogHelper.getStoredThrowableFile(any(UUID.class))).thenReturn(mock(File.class));
+        when(ErrorLogHelper.getErrorReportFromErrorLog(any(ManagedErrorLog.class), any(Throwable.class))).thenReturn(report1).thenReturn(report2);
+        when(StorageHelper.InternalStorage.read(any(File.class))).thenReturn("");
+        when(StorageHelper.InternalStorage.readObject(any(File.class))).thenReturn(new RuntimeException());
+        LogSerializer logSerializer = mock(LogSerializer.class);
+        when(logSerializer.deserializeLog(anyString())).thenAnswer(new Answer<ManagedErrorLog>() {
+
+            @Override
+            public ManagedErrorLog answer(InvocationOnMock invocation) throws Throwable {
+                ManagedErrorLog log = mock(ManagedErrorLog.class);
+                when(log.getId()).thenReturn(UUID.randomUUID());
+                return log;
+            }
+        });
+        Crashes crashes = Crashes.getInstance();
+        crashes.setLogSerializer(logSerializer);
+
+        /* Set manual processing. */
+        WrapperSdkExceptionManager.setAutomaticProcessing(false);
+
+        /* Start crashes. */
+        crashes.onStarting(mMobileCenterHandler);
+        crashes.onStarted(mockContext, "", mockChannel);
+
+        /* No log queued. */
+        verify(mockChannel, never()).enqueue(any(Log.class), eq(crashes.getGroupName()));
+
+        /* Get crash reports. */
+        Collection<ErrorReport> reports = WrapperSdkExceptionManager.getUnprocessedErrorReports().get();
+        assertNotNull(reports);
+        assertEquals(2, reports.size());
+        Iterator<ErrorReport> iterator = reports.iterator();
+        assertEquals(report1, iterator.next());
+        assertEquals(report2, iterator.next());
+
+        /* Send nothing using null. */
+        WrapperSdkExceptionManager.sendCrashReportsOrAwaitUserConfirmation(null);
+
+        /* No log sent. */
+        verify(mockChannel, never()).enqueue(any(ManagedErrorLog.class), eq(crashes.getGroupName()));
     }
 }


### PR DESCRIPTION
So that React Native can use JS listener for everything like other SDKs.