### PR TITLE
Only show in-app update failure message once per release

### DIFF
--- a/sdk/mobile-center-distribute/src/androidTest/java/com/microsoft/azure/mobile/distribute/BrowserUtilsTest.java
+++ b/sdk/mobile-center-distribute/src/androidTest/java/com/microsoft/azure/mobile/distribute/BrowserUtilsTest.java
@@ -12,11 +12,13 @@ import org.junit.Test;
 import org.mockito.ArgumentMatcher;
 import org.mockito.InOrder;
 
+import java.net.URISyntaxException;
 import java.util.Collections;
 
 import static com.microsoft.azure.mobile.distribute.BrowserUtils.GOOGLE_CHROME_URL_SCHEME;
 import static java.util.Arrays.asList;
 import static org.junit.Assert.assertNotNull;
+import static junit.framework.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.argThat;
@@ -45,6 +47,20 @@ public class BrowserUtilsTest {
     @Test
     public void init() {
         assertNotNull(new BrowserUtils());
+    }
+
+    @Test
+    public void appendQueryToUriWithNoQuery() throws URISyntaxException {
+        String url = "http://mock";
+        url = BrowserUtils.appendUri(url, "x=y");
+        assertEquals(url, "http://mock?x=y");
+    }
+
+    @Test
+    public void appendQueryToUriWithExistingQuery() throws URISyntaxException {
+        String url = "http://mock?a=b";
+        url = BrowserUtils.appendUri(url, "x=y");
+        assertEquals(url, "http://mock?a=b&x=y");
     }
 
     @Test

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/BrowserUtils.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/BrowserUtils.java
@@ -12,6 +12,8 @@ import android.support.annotation.VisibleForTesting;
 
 import com.microsoft.azure.mobile.utils.MobileCenterLog;
 
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.LOG_TAG;
@@ -100,5 +102,25 @@ class BrowserUtils {
                 activity.startActivity(intent);
             }
         }
+    }
+
+    /**
+     * Append a query parameter to an existing URI.
+     *
+     * @param uri         initial uri.
+     * @param appendQuery parameter to append.
+     */
+    static String appendUri(@NonNull String uri, @NonNull String appendQuery) throws URISyntaxException {
+        URI oldUri = new URI(uri);
+        String newQuery = oldUri.getQuery();
+        if (newQuery == null) {
+            newQuery = appendQuery;
+        } else {
+            newQuery += "&" + appendQuery;
+        }
+        URI newUri = new URI(oldUri.getScheme(), oldUri.getAuthority(),
+                oldUri.getPath(), newQuery, oldUri.getFragment());
+
+        return newUri.toString();
     }
 }

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/BrowserUtils.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/BrowserUtils.java
@@ -109,6 +109,8 @@ class BrowserUtils {
      *
      * @param uri         initial uri.
      * @param appendQuery parameter to append.
+     *
+     * @return uri string with appended query item.
      */
     static String appendUri(@NonNull String uri, @NonNull String appendQuery) throws URISyntaxException {
         URI oldUri = new URI(uri);
@@ -120,7 +122,6 @@ class BrowserUtils {
         }
         URI newUri = new URI(oldUri.getScheme(), oldUri.getAuthority(),
                 oldUri.getPath(), newQuery, oldUri.getFragment());
-
         return newUri.toString();
     }
 }

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DeepLinkActivity.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DeepLinkActivity.java
@@ -9,6 +9,7 @@ import com.microsoft.azure.mobile.utils.MobileCenterLog;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.EXTRA_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.EXTRA_REQUEST_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.EXTRA_UPDATE_TOKEN;
+import static com.microsoft.azure.mobile.distribute.DistributeConstants.EXTRA_UPDATE_SETUP_FAILED;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.LOG_TAG;
 
 /**
@@ -25,14 +26,19 @@ public class DeepLinkActivity extends Activity {
         String requestId = intent.getStringExtra(EXTRA_REQUEST_ID);
         String distributionGroupId = intent.getStringExtra(EXTRA_DISTRIBUTION_GROUP_ID);
         String updateToken = intent.getStringExtra(EXTRA_UPDATE_TOKEN);
+        String updateSetupFailed = intent.getStringExtra(EXTRA_UPDATE_SETUP_FAILED);
         MobileCenterLog.debug(LOG_TAG, getLocalClassName() + ".getIntent()=" + intent);
         MobileCenterLog.debug(LOG_TAG, "Intent requestId=" + requestId);
         MobileCenterLog.debug(LOG_TAG, "Intent distributionGroupId=" + distributionGroupId);
         MobileCenterLog.debug(LOG_TAG, "Intent updateToken passed=" + (updateToken != null));
+        MobileCenterLog.debug(LOG_TAG, "Intent updateSetupFailed passed=" + (updateSetupFailed != null));
 
         /* Store redirection parameters if both required values were passed. */
         if (requestId != null && distributionGroupId != null) {
             Distribute.getInstance().storeRedirectionParameters(requestId, distributionGroupId, updateToken);
+        } else if (updateSetupFailed != null){
+            // Otherwise just store error message to show update failure dialog in future.
+            Distribute.getInstance().storeUpdateSetupFailedParameter(updateSetupFailed);
         }
 
         /*

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DeepLinkActivity.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DeepLinkActivity.java
@@ -36,8 +36,9 @@ public class DeepLinkActivity extends Activity {
         /* Store redirection parameters if both required values were passed. */
         if (requestId != null && distributionGroupId != null) {
             Distribute.getInstance().storeRedirectionParameters(requestId, distributionGroupId, updateToken);
-        } else if (updateSetupFailed != null){
-            // Otherwise just store error message to show update failure dialog in future.
+        } else if (updateSetupFailed != null) {
+
+            /* Otherwise just store error message to show update failure dialog in future. */
             Distribute.getInstance().storeUpdateSetupFailedParameter(updateSetupFailed);
         }
 

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DeepLinkActivity.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DeepLinkActivity.java
@@ -36,10 +36,10 @@ public class DeepLinkActivity extends Activity {
         /* Store redirection parameters if both required values were passed. */
         if (requestId != null && distributionGroupId != null) {
             Distribute.getInstance().storeRedirectionParameters(requestId, distributionGroupId, updateToken);
-        } else if (updateSetupFailed != null) {
+        } else if (requestId != null && updateSetupFailed != null) {
 
             /* Otherwise just store error message to show update failure dialog in future. */
-            Distribute.getInstance().storeUpdateSetupFailedParameter(updateSetupFailed);
+            Distribute.getInstance().storeUpdateSetupFailedParameter(requestId, updateSetupFailed);
         }
 
         /*

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -1129,7 +1129,7 @@ public class Distribute extends AbstractMobileCenterService {
     /**
      * Store failed package info hash in preferences.
      */
-    private synchronized void storeUpdateSetupFailedPackageHash(Dialog dialog) {
+    private synchronized void storeUpdateSetupFailedPackageHash(DialogInterface dialog) {
         if (mUpdateSetupFailedDialog == dialog) {
             PreferencesStorage.putString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY, DistributeUtils.computeReleaseHash(mPackageInfo));
         } else {
@@ -1140,9 +1140,8 @@ public class Distribute extends AbstractMobileCenterService {
     /**
      * Redirect user to install url page in browser and clear current failed package hash from preferences.
      */
-    private synchronized void handleUpdateFailedDialogReinstallAction(Dialog dialog) {
+    private synchronized void handleUpdateFailedDialogReinstallAction(DialogInterface dialog) {
         if (mUpdateSetupFailedDialog == dialog) {
-
             /* Add a flag to the install url to indicate that the update setup failed, to show a help page. */
             String url = mInstallUrl;
             try {
@@ -1235,14 +1234,14 @@ public class Distribute extends AbstractMobileCenterService {
 
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
-                    storeUpdateSetupFailedPackageHash(mUpdateSetupFailedDialog);
+                    storeUpdateSetupFailedPackageHash(dialog);
                 }
             });
             dialogBuilder.setNegativeButton(R.string.mobile_center_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
 
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
-                    handleUpdateFailedDialogReinstallAction(mUpdateSetupFailedDialog);
+                    handleUpdateFailedDialogReinstallAction(dialog);
                 }
             });
             mUpdateSetupFailedDialog = dialogBuilder.create();

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -76,6 +76,7 @@ import static com.microsoft.azure.mobile.distribute.DistributeConstants.LOG_TAG;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.MEBIBYTE_IN_BYTES;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.NOTIFICATION_CHANNEL_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.POSTPONE_TIME_THRESHOLD;
+import static com.microsoft.azure.mobile.distribute.DistributeConstants.EXTRA_UPDATE_SETUP_FAILED;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
@@ -84,6 +85,8 @@ import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFEREN
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_RELEASE_DETAILS;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_REQUEST_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_TOKEN;
+import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY;
+import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.SERVICE_NAME;
 import static com.microsoft.azure.mobile.distribute.DistributeUtils.computeReleaseHash;
 import static com.microsoft.azure.mobile.distribute.DistributeUtils.getStoredDownloadState;
@@ -190,6 +193,11 @@ public class Distribute extends AbstractMobileCenterService {
      * Mandatory download completed in app notification.
      */
     private Dialog mCompletedDownloadDialog;
+
+    /**
+     * Update setup failed dialog.
+     */
+    private Dialog mUpdateSetupFailedDialog;
 
     /**
      * Last activity that did show a dialog.
@@ -501,6 +509,7 @@ public class Distribute extends AbstractMobileCenterService {
         mUnknownSourcesDialog = null;
         mProgressDialog = null;
         mCompletedDownloadDialog = null;
+        mUpdateSetupFailedDialog = null;
         mLastActivityWithDialog.clear();
         mUsingDefaultUpdateDialog = null;
         mReleaseDetails = null;
@@ -542,6 +551,21 @@ public class Distribute extends AbstractMobileCenterService {
                 MobileCenterLog.info(LOG_TAG, "Not checking in app updates as installed from a store.");
                 mWorkflowCompleted = true;
                 return;
+            }
+
+            // If failed to enable in-app updates on the same app build before, don't go any further.
+            // Only if the app build is different (different package hash), try enabling in-app updates again.
+            String releaseHash = DistributeUtils.computeReleaseHash(this.mPackageInfo);
+            String updateSetupFailedPackageHash = PreferencesStorage.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
+            if (updateSetupFailedPackageHash != null) {
+                if (releaseHash.equals(updateSetupFailedPackageHash)) {
+                    MobileCenterLog.info(LOG_TAG, "Skipping in-app updates setup, because it already failed on this release before.");
+                    return;
+                } else {
+                    MobileCenterLog.info(LOG_TAG, "Re-attempting in-app updates setup and cleaning up failure info from storage.");
+                    PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
+                    PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+                }
             }
 
             /* If we received the redirection parameters before Mobile Center was started/enabled, process them now. */
@@ -643,6 +667,16 @@ public class Distribute extends AbstractMobileCenterService {
                 }
             }
 
+            // If the in-app updates setup failed, and user ignores the failure, store the error
+            // message and also store the package hash that the failure occurred on. The setup
+            // will only be re-attempted the next time the app gets updated (and package hash changes).
+            String updateSetupFailedMessage = PreferencesStorage.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+            if (updateSetupFailedMessage != null){
+                MobileCenterLog.debug(LOG_TAG, "In-app updates setup failure detected.");
+                showUpdateSetupFailedDialog(updateSetupFailedMessage);
+                return;
+            }
+
             /* Nothing more to do for now if we are already calling API to check release. */
             if (mCheckReleaseCallId != null) {
                 MobileCenterLog.verbose(LOG_TAG, "Already checking or checked latest release.");
@@ -719,12 +753,21 @@ public class Distribute extends AbstractMobileCenterService {
         mCheckReleaseApiCall = null;
         mCheckReleaseCallId = null;
         mUpdateDialog = null;
+        mUpdateSetupFailedDialog = null;
         mUnknownSourcesDialog = null;
         hideProgressDialog();
         mLastActivityWithDialog.clear();
         mUsingDefaultUpdateDialog = null;
         mReleaseDetails = null;
         mWorkflowCompleted = true;
+    }
+
+    /*
+     * Store update update setup failure message used later to show in setup failure dialog for user.
+     */
+    synchronized void storeUpdateSetupFailedParameter(@NonNull String updateSetupFailed) {
+        MobileCenterLog.debug(LOG_TAG, "Stored update setup failed parameter.");
+        PreferencesStorage.putString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY, updateSetupFailed);
     }
 
     /*
@@ -1128,6 +1171,51 @@ public class Distribute extends AbstractMobileCenterService {
         mUnknownSourcesDialog = dialogBuilder.create();
         showAndRememberDialogActivity(mUnknownSourcesDialog);
     }
+
+    /**
+     * Show update setupp failed dialog.
+     */
+    @UiThread
+    private synchronized void showUpdateSetupFailedDialog(final String errorMessage) {
+        /* Check if we need to replace dialog. */
+        if (!shouldRefreshDialog(mUpdateSetupFailedDialog)){
+            return;
+        }
+        MobileCenterLog.debug(LOG_TAG, "Show update setup failed dialog.");
+
+        if (mForegroundActivity != null) {
+            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mForegroundActivity);
+            dialogBuilder.setCancelable(false);
+            dialogBuilder.setTitle(R.string.mobile_center_distribute_update_failed_dialog_title);
+            dialogBuilder.setMessage(errorMessage);
+            dialogBuilder.setPositiveButton(R.string.mobile_center_distribute_update_failed_dialog_ignore, new DialogInterface.OnClickListener() {
+
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    PreferencesStorage.putString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY, DistributeUtils.computeReleaseHash(mPackageInfo));
+                }
+            });
+            dialogBuilder.setNegativeButton(R.string.mobile_center_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
+
+                @Override
+                public void onClick(DialogInterface dialog, int which) {
+                    String url = mInstallUrl;
+                    // Add a flag to the install url to indicate that the update setup failed, to show a help page
+                    url += "?" + EXTRA_UPDATE_SETUP_FAILED + "=" + "true";
+                    BrowserUtils.openBrowser(url, mForegroundActivity);
+
+                    // Clear the update setup failure info from storage, to re-attempt setup on reinstall
+                    PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
+                }
+            });
+            mUpdateSetupFailedDialog = dialogBuilder.create();
+            showAndRememberDialogActivity(mUpdateSetupFailedDialog);
+
+            // Don't show this dialog again
+            PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
+        }
+    }
+
 
     /**
      * Navigate to security settings or application settings on Android O.

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -1457,7 +1457,7 @@ public class Distribute extends AbstractMobileCenterService {
             builder = new Notification.Builder(mContext, NOTIFICATION_CHANNEL_ID);
         } else {
 
-            /* noinspection deprecation. */
+            //noinspection deprecation
             builder = new Notification.Builder(mContext);
         }
         builder.setTicker(mContext.getString(R.string.mobile_center_distribute_install_ready_title))

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -1129,8 +1129,8 @@ public class Distribute extends AbstractMobileCenterService {
     /**
      * Store failed package info hash in preferences.
      */
-    private synchronized void storeUpdateSetupFailedPackageHash() {
-        if (mPackageInfo != null && mUpdateSetupFailedDialog != null) {
+    private synchronized void storeUpdateSetupFailedPackageHash(Dialog dialog) {
+        if (mUpdateSetupFailedDialog == dialog) {
             PreferencesStorage.putString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY, DistributeUtils.computeReleaseHash(mPackageInfo));
         } else {
             showDisabledToast();
@@ -1140,8 +1140,8 @@ public class Distribute extends AbstractMobileCenterService {
     /**
      * Redirect user to install url page in browser and clear current failed package hash from preferences.
      */
-    private synchronized void handleUpdateFailedDialogReinstallAction() {
-        if (mUpdateSetupFailedDialog != null) {
+    private synchronized void handleUpdateFailedDialogReinstallAction(Dialog dialog) {
+        if (mUpdateSetupFailedDialog == dialog) {
 
             /* Add a flag to the install url to indicate that the update setup failed, to show a help page. */
             String url = mInstallUrl;
@@ -1235,14 +1235,14 @@ public class Distribute extends AbstractMobileCenterService {
 
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
-                    storeUpdateSetupFailedPackageHash();
+                    storeUpdateSetupFailedPackageHash(mUpdateSetupFailedDialog);
                 }
             });
             dialogBuilder.setNegativeButton(R.string.mobile_center_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
 
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
-                    handleUpdateFailedDialogReinstallAction();
+                    handleUpdateFailedDialogReinstallAction(mUpdateSetupFailedDialog);
                 }
             });
             mUpdateSetupFailedDialog = dialogBuilder.create();

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -1142,6 +1142,7 @@ public class Distribute extends AbstractMobileCenterService {
      */
     private synchronized void handleUpdateFailedDialogReinstallAction(DialogInterface dialog) {
         if (mUpdateSetupFailedDialog == dialog) {
+
             /* Add a flag to the install url to indicate that the update setup failed, to show a help page. */
             String url = mInstallUrl;
             try {

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -77,6 +77,7 @@ import static com.microsoft.azure.mobile.distribute.DistributeConstants.MEBIBYTE
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.NOTIFICATION_CHANNEL_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.POSTPONE_TIME_THRESHOLD;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.EXTRA_UPDATE_SETUP_FAILED;
+import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_UPDATE_SETUP_FAILED;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DISTRIBUTION_GROUP_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
@@ -671,7 +672,7 @@ public class Distribute extends AbstractMobileCenterService {
             // message and also store the package hash that the failure occurred on. The setup
             // will only be re-attempted the next time the app gets updated (and package hash changes).
             String updateSetupFailedMessage = PreferencesStorage.getString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
-            if (updateSetupFailedMessage != null){
+            if (updateSetupFailedMessage != null) {
                 MobileCenterLog.debug(LOG_TAG, "In-app updates setup failure detected.");
                 showUpdateSetupFailedDialog(updateSetupFailedMessage);
                 return;
@@ -762,7 +763,7 @@ public class Distribute extends AbstractMobileCenterService {
         mWorkflowCompleted = true;
     }
 
-    /*
+    /**
      * Store update update setup failure message used later to show in setup failure dialog for user.
      */
     synchronized void storeUpdateSetupFailedParameter(@NonNull String updateSetupFailed) {
@@ -770,7 +771,7 @@ public class Distribute extends AbstractMobileCenterService {
         PreferencesStorage.putString(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY, updateSetupFailed);
     }
 
-    /*
+    /**
      * Store update token and possibly trigger application update check.
      */
     synchronized void storeRedirectionParameters(@NonNull String requestId, @NonNull String distributionGroupId, String updateToken) {
@@ -1177,8 +1178,9 @@ public class Distribute extends AbstractMobileCenterService {
      */
     @UiThread
     private synchronized void showUpdateSetupFailedDialog(final String errorMessage) {
+
         /* Check if we need to replace dialog. */
-        if (!shouldRefreshDialog(mUpdateSetupFailedDialog)){
+        if (!shouldRefreshDialog(mUpdateSetupFailedDialog)) {
             return;
         }
         MobileCenterLog.debug(LOG_TAG, "Show update setup failed dialog.");
@@ -1199,19 +1201,20 @@ public class Distribute extends AbstractMobileCenterService {
 
                 @Override
                 public void onClick(DialogInterface dialog, int which) {
+
+                    /* Add a flag to the install url to indicate that the update setup failed, to show a help page. */
                     String url = mInstallUrl;
-                    // Add a flag to the install url to indicate that the update setup failed, to show a help page
-                    url += "?" + EXTRA_UPDATE_SETUP_FAILED + "=" + "true";
+                    url += "?" + PARAMETER_UPDATE_SETUP_FAILED + "=" + "true";
                     BrowserUtils.openBrowser(url, mForegroundActivity);
 
-                    // Clear the update setup failure info from storage, to re-attempt setup on reinstall
+                    /* Clear the update setup failure info from storage, to re-attempt setup on reinstall. */
                     PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY);
                 }
             });
             mUpdateSetupFailedDialog = dialogBuilder.create();
             showAndRememberDialogActivity(mUpdateSetupFailedDialog);
 
-            // Don't show this dialog again
+            /* Don't show this dialog again. */
             PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
         }
     }

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -1226,33 +1226,30 @@ public class Distribute extends AbstractMobileCenterService {
             return;
         }
         MobileCenterLog.debug(LOG_TAG, "Show update setup failed dialog.");
-        if (mForegroundActivity != null) {
-            AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mForegroundActivity);
-            dialogBuilder.setCancelable(false);
-            dialogBuilder.setTitle(R.string.mobile_center_distribute_update_failed_dialog_title);
-            dialogBuilder.setMessage(errorMessage);
-            dialogBuilder.setPositiveButton(R.string.mobile_center_distribute_update_failed_dialog_ignore, new DialogInterface.OnClickListener() {
+        AlertDialog.Builder dialogBuilder = new AlertDialog.Builder(mForegroundActivity);
+        dialogBuilder.setCancelable(false);
+        dialogBuilder.setTitle(R.string.mobile_center_distribute_update_failed_dialog_title);
+        dialogBuilder.setMessage(errorMessage);
+        dialogBuilder.setPositiveButton(R.string.mobile_center_distribute_update_failed_dialog_ignore, new DialogInterface.OnClickListener() {
 
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    storeUpdateSetupFailedPackageHash(dialog);
-                }
-            });
-            dialogBuilder.setNegativeButton(R.string.mobile_center_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                storeUpdateSetupFailedPackageHash(dialog);
+            }
+        });
+        dialogBuilder.setNegativeButton(R.string.mobile_center_distribute_update_failed_dialog_reinstall, new DialogInterface.OnClickListener() {
 
-                @Override
-                public void onClick(DialogInterface dialog, int which) {
-                    handleUpdateFailedDialogReinstallAction(dialog);
-                }
-            });
-            mUpdateSetupFailedDialog = dialogBuilder.create();
-            showAndRememberDialogActivity(mUpdateSetupFailedDialog);
+            @Override
+            public void onClick(DialogInterface dialog, int which) {
+                handleUpdateFailedDialogReinstallAction(dialog);
+            }
+        });
+        mUpdateSetupFailedDialog = dialogBuilder.create();
+        showAndRememberDialogActivity(mUpdateSetupFailedDialog);
 
-            /* Don't show this dialog again. */
-            PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
-        }
+        /* Don't show this dialog again. */
+        PreferencesStorage.remove(PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY);
     }
-
 
     /**
      * Navigate to security settings or application settings on Android O.

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/Distribute.java
@@ -52,6 +52,7 @@ import com.microsoft.azure.mobile.utils.storage.StorageHelper.PreferencesStorage
 import org.json.JSONException;
 
 import java.lang.ref.WeakReference;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.text.NumberFormat;
 import java.util.Date;
@@ -1204,7 +1205,11 @@ public class Distribute extends AbstractMobileCenterService {
 
                     /* Add a flag to the install url to indicate that the update setup failed, to show a help page. */
                     String url = mInstallUrl;
-                    url += "?" + PARAMETER_UPDATE_SETUP_FAILED + "=" + "true";
+                    try {
+                        url = BrowserUtils.appendUri(url, PARAMETER_UPDATE_SETUP_FAILED + "=" + "true");
+                    } catch (URISyntaxException e) {
+                        MobileCenterLog.error(LOG_TAG, "Could not append query parameter to url.", e);
+                    }
                     BrowserUtils.openBrowser(url, mForegroundActivity);
 
                     /* Clear the update setup failure info from storage, to re-attempt setup on reinstall. */

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DistributeConstants.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DistributeConstants.java
@@ -36,6 +36,11 @@ final class DistributeConstants {
     static final String EXTRA_DISTRIBUTION_GROUP_ID = "distribution_group_id";
 
     /**
+     * Used for deep link intent from browser, string field for update setup failed identifier.
+     */
+    static final String EXTRA_UPDATE_SETUP_FAILED = "update_setup_failed";
+
+    /**
      * Base URL used to open browser to check install and get API token to check latest release.
      */
     static final String DEFAULT_INSTALL_URL = "https://install.mobile.azure.com";
@@ -85,6 +90,16 @@ final class DistributeConstants {
      * API parameter value for this platform.
      */
     static final String PARAMETER_PLATFORM_VALUE = "Android";
+
+    /**
+     * API parameter for setup failure redirect key.
+     */
+    static final String PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY = "enable_failure_redirect";
+
+    /**
+     * API parameter value for setup failure redirect key.
+     */
+    static final String PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY_VALUE = "true";
 
     /**
      * Header used to pass token when checking latest release.
@@ -200,6 +215,16 @@ final class DistributeConstants {
      * Preference key to hold the time when user chose "ask me in a day".
      */
     static final String PREFERENCE_KEY_POSTPONE_TIME = PREFERENCE_PREFIX + "postpone_time";
+
+    /**
+     * Preference key for update setup failure package hash.
+     */
+    static final String PREFERENCE_KEY_UPDATE_SETUP_FAILED_PACKAGE_HASH_KEY = PREFERENCE_PREFIX + "update_setup_failed_package_hash";
+
+    /**
+     * Preference key for update setup failure error message.
+     */
+    static final String PREFERENCE_KEY_UPDATE_SETUP_FAILED_MESSAGE_KEY = PREFERENCE_PREFIX + "update_setup_failed_message";
 
     @VisibleForTesting
     DistributeConstants() {

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DistributeConstants.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DistributeConstants.java
@@ -97,9 +97,9 @@ final class DistributeConstants {
     static final String PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY = "enable_failure_redirect";
 
     /**
-     * API parameter value for setup failure redirect key.
+     * API parameter for update setup failed key.
      */
-    static final String PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY_VALUE = "true";
+    static final String PARAMETER_UPDATE_SETUP_FAILED = "update_setup_failed";
 
     /**
      * Header used to pass token when checking latest release.

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DistributeUtils.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DistributeUtils.java
@@ -24,6 +24,8 @@ import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETE
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_REDIRECT_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_RELEASE_HASH;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_REQUEST_ID;
+import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY;
+import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY_VALUE;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_RELEASE_DETAILS;
@@ -126,8 +128,8 @@ class DistributeUtils {
         url += "&" + PARAMETER_REDIRECT_ID + "=" + activity.getPackageName();
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId;
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
+        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY_VALUE;
         MobileCenterLog.debug(LOG_TAG, "No token, need to open browser to url=" + url);
-
         /* Store request id. */
         StorageHelper.PreferencesStorage.putString(PREFERENCE_KEY_REQUEST_ID, requestId);
 

--- a/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DistributeUtils.java
+++ b/sdk/mobile-center-distribute/src/main/java/com/microsoft/azure/mobile/distribute/DistributeUtils.java
@@ -25,7 +25,6 @@ import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETE
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_RELEASE_HASH;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_REQUEST_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY;
-import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY_VALUE;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_ID;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_DOWNLOAD_STATE;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PREFERENCE_KEY_RELEASE_DETAILS;
@@ -128,8 +127,9 @@ class DistributeUtils {
         url += "&" + PARAMETER_REDIRECT_ID + "=" + activity.getPackageName();
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId;
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
-        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY_VALUE;
+        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         MobileCenterLog.debug(LOG_TAG, "No token, need to open browser to url=" + url);
+
         /* Store request id. */
         StorageHelper.PreferencesStorage.putString(PREFERENCE_KEY_REQUEST_ID, requestId);
 

--- a/sdk/mobile-center-distribute/src/main/res/values/mobile_center_distribute.xml
+++ b/sdk/mobile-center-distribute/src/main/res/values/mobile_center_distribute.xml
@@ -15,4 +15,7 @@
     <string name="mobile_center_distribute_install_ready_message">%1$s %2$s (%3$d) has been downloaded and is ready to be installed.</string>
     <string name="mobile_center_distribute_install">Install</string>
     <string name="mobile_center_distribute_notification_category">App updates</string>
+    <string name="mobile_center_distribute_update_failed_dialog_title">In-app updates disabled</string>
+    <string name="mobile_center_distribute_update_failed_dialog_ignore">Ignore</string>
+    <string name="mobile_center_distribute_update_failed_dialog_reinstall">Reinstall app</string>
 </resources>

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DeepLinkActivityTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DeepLinkActivityTest.java
@@ -11,6 +11,7 @@ import org.powermock.core.classloader.annotations.PrepareForTest;
 import org.powermock.modules.junit4.PowerMockRunner;
 
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.spy;
@@ -70,6 +71,27 @@ public class DeepLinkActivityTest {
         Intent intent = mock(Intent.class);
         when(intent.getStringExtra(DistributeConstants.EXTRA_REQUEST_ID)).thenReturn("mock");
         invalidIntent(intent);
+    }
+
+    @Test
+    public void vaidWithUpdateSetupFailedAndNoTaskRoot() {
+
+         /* Build valid intent. */
+        Intent intent = mock(Intent.class);
+        when(intent.getStringExtra(DistributeConstants.EXTRA_REQUEST_ID)).thenReturn("mock1");
+        when(intent.getStringExtra(DistributeConstants.EXTRA_UPDATE_SETUP_FAILED)).thenReturn("mock2");
+        when(intent.getFlags()).thenReturn(Intent.FLAG_ACTIVITY_NEW_TASK | Intent.FLAG_ACTIVITY_LAUNCHED_FROM_HISTORY);
+
+        /* Start activity. */
+        DeepLinkActivity activity = spy(new DeepLinkActivity());
+        when(activity.getIntent()).thenReturn(intent);
+        activity.onCreate(null);
+
+         /* Verify interactions. */
+        verify(activity, never()).startActivity(any(Intent.class));
+        verify(mDistribute, never()).storeRedirectionParameters(anyString(), anyString(), anyString());
+        verify(activity).finish();
+        verify(mDistribute).storeUpdateSetupFailedParameter("mock1", "mock2");
     }
 
     @Test

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DistributeBeforeApiSuccessTest.java
@@ -37,6 +37,7 @@ import java.util.concurrent.atomic.AtomicReference;
 
 import javax.net.ssl.SSLPeerUnverifiedException;
 
+import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_PLATFORM;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_PLATFORM_VALUE;
 import static com.microsoft.azure.mobile.distribute.DistributeConstants.PARAMETER_REDIRECT_ID;
@@ -270,6 +271,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REDIRECT_ID + "=" + mContext.getPackageName();
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
+        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         PreferencesStorage.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -387,6 +389,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REDIRECT_ID + "=" + mContext.getPackageName();
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
+        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         PreferencesStorage.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -504,6 +507,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REDIRECT_ID + "=" + mContext.getPackageName();
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
+        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         PreferencesStorage.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());
@@ -556,6 +560,7 @@ public class DistributeBeforeApiSuccessTest extends AbstractDistributeTest {
         url += "&" + PARAMETER_REDIRECT_ID + "=" + mContext.getPackageName();
         url += "&" + PARAMETER_REQUEST_ID + "=" + requestId.toString();
         url += "&" + PARAMETER_PLATFORM + "=" + PARAMETER_PLATFORM_VALUE;
+        url += "&" + PARAMETER_ENABLE_UPDATE_SETUP_FAILURE_REDIRECT_KEY + "=" + "true";
         BrowserUtils.openBrowser(url, mActivity);
         verifyStatic();
         PreferencesStorage.putString(PREFERENCE_KEY_REQUEST_ID, requestId.toString());

--- a/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DistributeBeforeApiSuccessTest.java
+++ b/sdk/mobile-center-distribute/src/test/java/com/microsoft/azure/mobile/distribute/DistributeBeforeApiSuccessTest.java
@@ -24,7 +24,6 @@ import com.microsoft.azure.mobile.utils.crypto.CryptoUtils;
 
 import org.json.JSONException;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.internal.matchers.Any;
@@ -34,7 +33,6 @@ import org.mockito.stubbing.Answer;
 import org.mockito.verification.VerificationMode;
 import org.powermock.api.mockito.PowerMockito;
 import org.powermock.core.classloader.annotations.PrepareForTest;
-import org.powermock.modules.junit4.PowerMockRunner;
 
 import java.net.URISyntaxException;
 import java.util.HashMap;


### PR DESCRIPTION
The aim of this PR is to bring the similar functionality as was currently created at iOS SDK: https://github.com/Microsoft/mobile-center-sdk-ios/pull/773.

Any feedback and remarks are much appreciated. 

